### PR TITLE
Complete Memco go-live remediation and operator gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 MEMCO_ROOT=.
 MEMCO_API_HOST=127.0.0.1
 MEMCO_API_PORT=8788
-MEMCO_API_TOKEN=
-MEMCO_LLM_PROVIDER=mock
-MEMCO_LLM_MODEL=fixture
+MEMCO_API_TOKEN=replace-with-local-token
+MEMCO_STORAGE_ENGINE=postgres
+MEMCO_DATABASE_URL=postgresql://martin@127.0.0.1:5432/memco_local
+MEMCO_BACKUP_PATH=/absolute/path/to/memco-postgres.dump
+MEMCO_LLM_PROVIDER=openai-compatible
+MEMCO_LLM_MODEL=gpt-4o-mini
+MEMCO_LLM_BASE_URL=https://api.openai.com/v1
+MEMCO_LLM_API_KEY=replace-with-provider-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
         run: uv run pytest -q
 
       - name: Run acceptance eval gate
+        env:
+          MEMCO_LLM_API_KEY: ci-placeholder-key
+          MEMCO_API_TOKEN: ci-placeholder-token
+          MEMCO_BACKUP_PATH: ${{ github.workspace }}/var/backups/memco-postgres.dump
         run: |
+          mkdir -p "$(dirname "$MEMCO_BACKUP_PATH")"
+          : > "$MEMCO_BACKUP_PATH"
           uv run python - <<'PY'
           import json
           from pathlib import Path

--- a/README.md
+++ b/README.md
@@ -191,7 +191,18 @@ If you want the canonical Postgres gate instead of the quick local fallback path
 uv run memco release-check --postgres-database-url 'postgresql://USER@127.0.0.1:5432/postgres'
 ```
 
-That variant runs pytest plus the acceptance artifact on Postgres and then requires the no-Docker API bootstrap smoke. It returns one combined JSON artifact for the canonical Postgres path.
+That variant runs runtime policy, storage contract, operator safety, pytest, the acceptance artifact on Postgres, and the no-Docker API bootstrap smoke. It returns one combined JSON artifact for the canonical Postgres path.
+
+To fold the live operator smoke into the same gate:
+
+```bash
+MEMCO_RUN_LIVE_SMOKE=1 \
+MEMCO_API_TOKEN='replace-with-local-token' \
+MEMCO_LLM_API_KEY='replace-with-provider-key' \
+uv run memco release-check \
+  --project-root /Users/martin/memco \
+  --postgres-database-url 'postgresql://USER@127.0.0.1:5432/postgres'
+```
 
 If you want the full benchmark-backed quality claim instead of an acceptance-only gate:
 
@@ -207,6 +218,7 @@ In this checkout, the latest persisted repo-local gate artifacts are typically k
 - `var/reports/release-check-postgres-current.json`
 - `var/reports/strict-release-check-current.json`
 - `var/reports/benchmark-current.json`
+- `var/reports/live-operator-smoke-current.json`
 - `var/reports/repo-local-status-current.json`
 - `var/reports/change-groups-current.json`
 - `var/reports/local-artifacts-refresh-current.json`

--- a/docs/2026-04-21_memco_release_readiness_gate.md
+++ b/docs/2026-04-21_memco_release_readiness_gate.md
@@ -75,6 +75,14 @@ uv run memco release-check --output /absolute/path/to/release-check.json
 # Optional no-Docker Postgres verification inside the same gate:
 uv run memco release-check --postgres-database-url 'postgresql://USER@127.0.0.1:5432/postgres'
 
+# Optional live operator smoke folded into the same gate:
+MEMCO_RUN_LIVE_SMOKE=1 \
+MEMCO_API_TOKEN='replace-with-local-token' \
+MEMCO_LLM_API_KEY='replace-with-provider-key' \
+uv run memco release-check \
+  --project-root /Users/martin/memco \
+  --postgres-database-url 'postgresql://USER@127.0.0.1:5432/postgres'
+
 # Equivalent expanded commands:
 uv run pytest -q \
   tests/test_ingest_service.py \
@@ -107,10 +115,10 @@ uv run memco local-artifacts-refresh --project-root /Users/martin/memco
 Most recent recorded evidence:
 
 - contract-facing regression stack:
-  - `46 passed`
+  - `74 passed in 4.45s`
 - active repo-local release-check pytest gate: `47 passed`
 - expanded eval artifact on clean root: `total=24`, `passed=24`, `pass_rate=1.0`, `token_accounting.status=tracked`
-- full local test suite: `266 passed`
+- full local test suite: `321 passed in 9.57s`
 - no-Docker Postgres live proof:
   - `uv run memco-api` with `MEMCO_STORAGE_ENGINE=postgres`
   - `/health` returned `storage_engine=postgres`
@@ -131,7 +139,7 @@ Most recent recorded evidence:
   - passed locally against the quick repo-local gate
   - latest local artifact:
     - `pytest_gate`: `47 passed`
-    - `acceptance_artifact`: `24/24 passed`
+    - `acceptance_artifact`: `27/27 passed`
     - saved artifact:
       - `var/reports/release-check-current.json`
   - implementation note:
@@ -148,6 +156,7 @@ Most recent recorded evidence:
     - passed locally and produced a single artifact with `pytest_gate`, `acceptance_artifact` on Postgres, and `postgres_smoke`
     - latest saved artifact:
       - `var/reports/release-check-postgres-current.json`
+      - `var/reports/live-operator-smoke-current.json`
   - strict benchmark-backed quality variant:
     - `uv run memco strict-release-check --postgres-database-url 'postgresql://USER@127.0.0.1:5432/postgres'`
     - this is the gate to use for the full quality claim once benchmark thresholds matter
@@ -217,5 +226,6 @@ Historical Docker recovery notes remain here for reference:
 - `.github/workflows/ci.yml` now enforces the full pytest suite plus an eval-only gate step using the same `run_release_check` helper logic, avoiding duplicated pytest-subset work in CI.
 - `memco release-check` is the local executable entrypoint for the active repo-local release gate.
 - `memco release-check --postgres-database-url ...` is the optional local executable path for folding no-Docker Postgres smoke into the same release artifact.
+- `MEMCO_RUN_LIVE_SMOKE=1 memco release-check --postgres-database-url ...` adds the API-first live operator smoke and writes `var/reports/live-operator-smoke-current.json`.
 - `memco release-check --project-root ...` makes the repo-local tree assumption explicit instead of relying on the package file location.
 - `memco release-check --output ...` makes the release artifact reproducibly storable without shell redirection.

--- a/docs/2026-04-22_memco_repo_local_status_snapshot.md
+++ b/docs/2026-04-22_memco_repo_local_status_snapshot.md
@@ -20,23 +20,26 @@ Separate reference-track status:
 
 Full suite:
 
-- `uv run pytest -q` -> `266 passed`
+- `uv run pytest -q` -> `321 passed in 9.57s`
 
 Repo-local release gate:
 
 - `uv run memco release-check --project-root /Users/martin/memco` -> `ok: true`
 - pytest gate inside release-check -> `47 passed`
-- acceptance artifact -> `24/24 passed`
+- acceptance artifact -> `27/27 passed`
 - temporary acceptance root intentionally uses SQLite fallback when no local runtime config exists there
 
 Contract-facing regression stack:
 
-- `uv run pytest -q tests/test_docs_contract.py tests/test_release_check.py tests/test_cli_release_check.py tests/test_config.py tests/test_llm_provider.py` -> `46 passed`
+- `uv run pytest -q tests/test_docs_contract.py tests/test_release_check.py tests/test_cli_release_check.py tests/test_config.py tests/test_llm_provider.py` -> `74 passed in 4.45s`
 
 Optional no-Docker Postgres variant:
 
 - `uv run memco release-check --project-root /Users/martin/memco --postgres-database-url 'postgresql://martin@127.0.0.1:5432/postgres'` -> `ok: true`
 - postgres smoke -> `ok: true`
+- `MEMCO_RUN_LIVE_SMOKE=1 ... uv run memco release-check --project-root /Users/martin/memco --postgres-database-url 'postgresql://martin@127.0.0.1:5432/postgres'` -> `ok: true`
+- operator safety gate -> `ok: true`
+- live operator smoke -> `ok: true`
 
 ## Persisted Artifacts
 
@@ -44,6 +47,8 @@ Optional no-Docker Postgres variant:
   - `var/reports/release-check-current.json`
 - repo-local gate + Postgres smoke artifact:
   - `var/reports/release-check-postgres-current.json`
+- live operator smoke artifact:
+  - `var/reports/live-operator-smoke-current.json`
 - machine-readable local status snapshot:
   - `var/reports/repo-local-status-current.json`
   - mirrors the current branch, remote, contract split, and latest validation counts
@@ -90,6 +95,9 @@ Optional no-Docker Postgres variant:
 - positive agent-facing answers return:
   - `fact_ids`
   - `evidence_ids`
+- operator safety now requires:
+  - non-empty API token
+  - backup path present
 - RU/EN mixed-language regressions are present
 - pending-review exclusion is enforced as a hard eval gate
 - detail policy exists with:

--- a/docs/2026-04-22_postgres_without_docker.md
+++ b/docs/2026-04-22_postgres_without_docker.md
@@ -29,6 +29,8 @@ Set:
 ```bash
 export MEMCO_STORAGE_ENGINE=postgres
 export MEMCO_DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/DBNAME'
+export MEMCO_BACKUP_PATH='/absolute/path/to/memco-postgres.dump'
+export MEMCO_API_TOKEN='replace-with-local-token'
 ```
 
 Optional:
@@ -70,6 +72,8 @@ Expected health fields:
 
 - `"storage_engine": "postgres"`
 - `"database_target": "postgresql://..."`
+- `"api_token_configured": true`
+- `"backup_path_exists": true`
 
 ## Reproducible Smoke
 
@@ -138,3 +142,7 @@ Validated in this session:
   - `uv run memco strict-release-check --project-root /Users/martin/memco --postgres-database-url 'postgresql://martin@127.0.0.1:5432/postgres' --output /Users/martin/memco/var/reports/strict-release-check-current.json`
   - benchmark artifact:
     - `/Users/martin/memco/var/reports/benchmark-current.json`
+- live operator smoke can be folded into the same canonical gate:
+  - `MEMCO_RUN_LIVE_SMOKE=1 MEMCO_API_TOKEN='replace-with-local-token' MEMCO_LLM_API_KEY='replace-with-provider-key' uv run memco release-check --project-root /Users/martin/memco --postgres-database-url 'postgresql://martin@127.0.0.1:5432/postgres'`
+  - live smoke artifact:
+    - `/Users/martin/memco/var/reports/live-operator-smoke-current.json`

--- a/src/memco/api/routes/health.py
+++ b/src/memco/api/routes/health.py
@@ -17,6 +17,8 @@ def health():
         source_row = conn.execute("SELECT COUNT(*) AS count FROM sources").fetchone()
         person_row = conn.execute("SELECT COUNT(*) AS count FROM persons").fetchone()
         fact_row = conn.execute("SELECT COUNT(*) AS count FROM memory_facts").fetchone()
+    api_token_configured = bool((settings.api.auth_token or "").strip())
+    backup_path = settings.backup_path
     return {
         "ok": True,
         "root": str(settings.root),
@@ -26,6 +28,9 @@ def health():
         "storage_contract": settings.storage_contract,
         "storage_role": settings.storage_role,
         "database_target": settings.database_target,
+        "api_token_configured": api_token_configured,
+        "backup_path": str(backup_path),
+        "backup_path_exists": backup_path.exists(),
         "llm_runtime": llm_runtime_policy(settings),
         "counts": {
             "workspaces": int(workspace_row["count"]),

--- a/src/memco/config.py
+++ b/src/memco/config.py
@@ -51,7 +51,8 @@ class StorageSettings(BaseModel):
     engine: str = PRIMARY_STORAGE_ENGINE
     contract_engine: str = PRIMARY_STORAGE_ENGINE
     db_path: str = "var/db/memco.db"
-    database_url: str = "postgresql://memco:memco@127.0.0.1:5432/memco"
+    database_url: str = "postgresql://martin@127.0.0.1:5432/memco_local"
+    backup_path: str = "var/backups/memco-postgres.dump"
 
     @field_validator("engine", "contract_engine")
     @classmethod
@@ -112,6 +113,10 @@ class Settings(BaseModel):
         return "primary" if self.storage.engine == self.storage.contract_engine else "fallback"
 
     @property
+    def backup_path(self) -> Path:
+        return self.root / self.storage.backup_path
+
+    @property
     def config_path(self) -> Path:
         return self.root / "var" / "config" / "settings.yaml"
 
@@ -166,6 +171,7 @@ def load_settings(root: str | Path | None = None) -> Settings:
     env_llm_allow_mock_provider = os.environ.get("MEMCO_LLM_ALLOW_MOCK_PROVIDER")
     env_storage_engine = os.environ.get("MEMCO_STORAGE_ENGINE")
     env_database_url = os.environ.get("MEMCO_DATABASE_URL")
+    env_backup_path = os.environ.get("MEMCO_BACKUP_PATH")
     env_enable_retrieval_logs = os.environ.get("MEMCO_ENABLE_RETRIEVAL_LOGS")
     env_query_hash_salt = os.environ.get("MEMCO_QUERY_HASH_SALT")
     env_runtime_profile = os.environ.get("MEMCO_RUNTIME_PROFILE")
@@ -205,6 +211,9 @@ def load_settings(root: str | Path | None = None) -> Settings:
     if env_database_url is not None:
         storage = raw_data.setdefault("storage", {})
         storage["database_url"] = env_database_url
+    if env_backup_path is not None:
+        storage = raw_data.setdefault("storage", {})
+        storage["backup_path"] = env_backup_path
     if env_enable_retrieval_logs is not None:
         logging = raw_data.setdefault("logging", {})
         logging["enable_retrieval_logs"] = env_enable_retrieval_logs.strip().lower() in {"1", "true", "yes", "on"}

--- a/src/memco/extractors/base.py
+++ b/src/memco/extractors/base.py
@@ -235,9 +235,9 @@ def build_extraction_system_prompt(*, include_style: bool, include_psychometrics
         "You are the Memco extraction runtime. "
         "The live runtime path is LLM-first structured extraction. "
         "Rule-based extraction is fallback-only for fixture/test or emergency use. "
-        "Return strict JSON only. "
+        "Return strict json only. "
         "Use the contract below exactly. "
-        "Never return prose outside JSON. "
+        "Never return prose outside json. "
         f"include_style={str(include_style).lower()} "
         f"include_psychometrics={str(include_psychometrics).lower()}.\n"
         f"{json.dumps(contract_payload, ensure_ascii=False, sort_keys=True)}"
@@ -305,6 +305,7 @@ def build_prompt_payload(
     return {
         "contract_version": EXTRACTION_CONTRACT_VERSION,
         "extraction_mode": "llm_first_structured_extraction",
+        "json_output_required": True,
         "text": context.text,
         "subject_key": context.subject_key,
         "subject_display": context.subject_display,

--- a/src/memco/live_smoke.py
+++ b/src/memco/live_smoke.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from memco.api.deps import build_internal_actor
+from memco.config import Settings, write_settings
+from memco.postgres_admin import drop_postgres_database, ensure_postgres_database
+from memco.runtime import ensure_runtime
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _headers(*, api_token: str) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_token.strip():
+        headers["X-Memco-Token"] = api_token.strip()
+    return headers
+
+
+def _request_json(
+    *,
+    url: str,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 60,
+    retries: int = 0,
+) -> dict[str, Any]:
+    last_error: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            data = json.dumps(payload).encode("utf-8") if payload is not None else None
+            request = urllib.request.Request(
+                url=url,
+                data=data,
+                headers=headers or {},
+                method=method,
+            )
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            last_error = exc
+            if exc.code < 500 or attempt >= retries:
+                raise
+            time.sleep(0.5 * (attempt + 1))
+        except Exception as exc:
+            last_error = exc
+            if attempt >= retries:
+                raise
+            time.sleep(0.5 * (attempt + 1))
+    assert last_error is not None
+    raise last_error
+
+
+def _wait_http(url: str, *, timeout_seconds: int = 30) -> dict[str, Any]:
+    started = time.time()
+    last_error: Exception | None = None
+    while time.time() - started < timeout_seconds:
+        try:
+            return _request_json(url=url, timeout=5)
+        except Exception as exc:  # pragma: no cover - exercised in live runs
+            last_error = exc
+            time.sleep(0.5)
+    raise TimeoutError(f"Timed out waiting for {url}: {last_error}")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _runtime_settings(
+    *,
+    root: Path,
+    database_url: str,
+    provider: str,
+    model: str,
+    base_url: str,
+    api_key: str,
+    api_token: str,
+) -> Settings:
+    settings = Settings(root=root)
+    settings.runtime.profile = "repo-local"
+    settings.storage.engine = "postgres"
+    settings.storage.database_url = database_url
+    settings.llm.provider = provider
+    settings.llm.model = model
+    settings.llm.base_url = base_url
+    settings.llm.api_key = api_key
+    settings.api.auth_token = api_token
+    write_settings(settings)
+    return ensure_runtime(settings)
+
+
+def _source_file(root: Path, *, filename: str, messages: list[dict[str, str]]) -> Path:
+    path = root / "var" / "smoke" / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"messages": messages}, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _fact_categories(pipeline_payload: dict[str, Any]) -> set[tuple[str, str]]:
+    categories: set[tuple[str, str]] = set()
+    for item in pipeline_payload.get("published", []):
+        fact = item.get("fact") or {}
+        domain = str(fact.get("domain") or "")
+        category = str(fact.get("category") or "")
+        if domain and category:
+            categories.add((domain, category))
+    return categories
+
+
+def _step(*, name: str, ok: bool, **payload: Any) -> dict[str, Any]:
+    return {"name": name, "ok": ok, **payload}
+
+
+def run_live_operator_smoke(
+    *,
+    maintenance_database_url: str,
+    root: Path,
+    project_root: Path,
+    port: int | None = None,
+    output_path: Path | None = None,
+) -> dict[str, Any]:
+    provider = os.environ.get("MEMCO_LLM_PROVIDER", "").strip() or "openai-compatible"
+    model = os.environ.get("MEMCO_LLM_MODEL", "").strip() or "gpt-4o-mini"
+    base_url = os.environ.get("MEMCO_LLM_BASE_URL", "").strip()
+    api_key = os.environ.get("MEMCO_LLM_API_KEY", "").strip()
+    api_token = os.environ.get("MEMCO_API_TOKEN", "").strip() or "memco-live-smoke-token"
+    if not base_url:
+        raise ValueError("MEMCO_LLM_BASE_URL is required for live smoke")
+    if not api_key:
+        raise ValueError("MEMCO_LLM_API_KEY is required for live smoke")
+
+    selected_port = int(port or _free_port())
+    db_name = f"memco_live_smoke_{random.randint(10000, 99999)}"
+    run_db_url = ensure_postgres_database(
+        maintenance_database_url=maintenance_database_url,
+        db_name=db_name,
+    )
+    settings = _runtime_settings(
+        root=root,
+        database_url=run_db_url,
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        api_token=api_token,
+    )
+    admin_actor = build_internal_actor(settings, actor_id="maintenance-admin").model_dump(mode="json")
+    owner_actor = build_internal_actor(settings, actor_id="dev-owner").model_dump(mode="json")
+
+    alice_source = _source_file(
+        root,
+        filename="alice_live_smoke.json",
+        messages=[
+            {"speaker": "Alice", "timestamp": "2026-04-21T09:00:00Z", "text": "I live in Lisbon."},
+            {"speaker": "Alice", "timestamp": "2026-04-21T09:01:00Z", "text": "I like tea."},
+            {"speaker": "Alice", "timestamp": "2026-04-21T09:02:00Z", "text": "I work at Acme."},
+            {"speaker": "Alice", "timestamp": "2026-04-21T09:03:00Z", "text": "I am a product designer."},
+            {"speaker": "Alice", "timestamp": "2026-04-21T09:04:00Z", "text": "I use Figma."},
+            {"speaker": "Alice", "timestamp": "2026-04-21T09:05:00Z", "text": "I attended PyCon in 2024 with Bob."},
+        ],
+    )
+    bob_source = _source_file(
+        root,
+        filename="bob_live_smoke.json",
+        messages=[
+            {"speaker": "Bob", "timestamp": "2026-04-21T10:00:00Z", "text": "I live in Porto."},
+            {"speaker": "Bob", "timestamp": "2026-04-21T10:01:00Z", "text": "I like coffee."},
+            {"speaker": "Bob", "timestamp": "2026-04-21T10:02:00Z", "text": "I work at Contoso."},
+            {"speaker": "Bob", "timestamp": "2026-04-21T10:03:00Z", "text": "I am an engineer."},
+        ],
+    )
+
+    env = {
+        **os.environ,
+        "MEMCO_ROOT": str(root),
+        "MEMCO_API_HOST": "127.0.0.1",
+        "MEMCO_API_PORT": str(selected_port),
+    }
+    process = subprocess.Popen(
+        ["uv", "run", "memco-api"],
+        cwd=str(project_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    failures: list[str] = []
+    steps: list[dict[str, Any]] = []
+    artifact: dict[str, Any] = {}
+    try:
+        base = f"http://127.0.0.1:{selected_port}"
+        health = _wait_http(f"{base}/health")
+        steps.append(
+            _step(
+                name="health",
+                ok=health.get("storage_engine") == "postgres" and bool(health.get("llm_runtime", {}).get("release_eligible")),
+                storage_engine=health.get("storage_engine"),
+                storage_role=health.get("storage_role"),
+                release_eligible=health.get("llm_runtime", {}).get("release_eligible"),
+            )
+        )
+
+        request_headers = _headers(api_token=api_token)
+        alice_pipeline = _request_json(
+            url=f"{base}/v1/ingest/pipeline",
+            method="POST",
+            headers=request_headers,
+            retries=2,
+            payload={
+                "workspace": "default",
+                "path": str(alice_source),
+                "source_type": "json",
+                "person_display_name": "Alice",
+                "person_slug": "alice",
+                "aliases": ["Alice"],
+                "actor": admin_actor,
+            },
+        )
+        bob_pipeline = _request_json(
+            url=f"{base}/v1/ingest/pipeline",
+            method="POST",
+            headers=request_headers,
+            retries=2,
+            payload={
+                "workspace": "default",
+                "path": str(bob_source),
+                "source_type": "json",
+                "person_display_name": "Bob",
+                "person_slug": "bob",
+                "aliases": ["Bob"],
+                "actor": admin_actor,
+            },
+        )
+        published_total = len(alice_pipeline.get("published", [])) + len(bob_pipeline.get("published", []))
+        published_categories = sorted(_fact_categories(alice_pipeline) | _fact_categories(bob_pipeline))
+        steps.append(
+            _step(
+                name="ingest_pipeline",
+                ok=published_total >= 8,
+                published_total=published_total,
+                published_categories=published_categories,
+                pending_review_total=len(alice_pipeline.get("pending_review_items", []))
+                + len(bob_pipeline.get("pending_review_items", [])),
+            )
+        )
+
+        alice_retrieve = _request_json(
+            url=f"{base}/v1/retrieve",
+            method="POST",
+            headers=request_headers,
+            retries=1,
+            payload={
+                "workspace": "default",
+                "person_slug": "alice",
+                "query": "Where does Alice live?",
+                "detail_policy": "core_only",
+                "actor": owner_actor,
+            },
+        )
+        bob_retrieve = _request_json(
+            url=f"{base}/v1/retrieve",
+            method="POST",
+            headers=request_headers,
+            retries=1,
+            payload={
+                "workspace": "default",
+                "person_slug": "bob",
+                "query": "Where does Bob live?",
+                "detail_policy": "core_only",
+                "actor": owner_actor,
+            },
+        )
+        supported_chat = _request_json(
+            url=f"{base}/v1/chat",
+            method="POST",
+            headers=request_headers,
+            retries=1,
+            payload={
+                "workspace": "default",
+                "person_slug": "alice",
+                "query": "Where does Alice live?",
+                "detail_policy": "core_only",
+                "actor": owner_actor,
+            },
+        )
+        unsupported_chat = _request_json(
+            url=f"{base}/v1/chat",
+            method="POST",
+            headers=request_headers,
+            retries=1,
+            payload={
+                "workspace": "default",
+                "person_slug": "alice",
+                "query": "Is Bob Alice's brother?",
+                "actor": owner_actor,
+            },
+        )
+        contradicted_chat = _request_json(
+            url=f"{base}/v1/chat",
+            method="POST",
+            headers=request_headers,
+            retries=1,
+            payload={
+                "workspace": "default",
+                "person_slug": "alice",
+                "query": "Does Alice live in Berlin?",
+                "actor": owner_actor,
+            },
+        )
+        isolation_chat = _request_json(
+            url=f"{base}/v1/chat",
+            method="POST",
+            headers=request_headers,
+            retries=1,
+            payload={
+                "workspace": "default",
+                "person_slug": "alice",
+                "query": "Where does Bob live?",
+                "actor": owner_actor,
+            },
+        )
+        checks = {
+            "alice_retrieve_supported": bool(alice_retrieve.get("hits")),
+            "bob_retrieve_supported": bool(bob_retrieve.get("hits")),
+            "supported_chat_has_fact_ids": not supported_chat.get("refused", True)
+            and bool(supported_chat.get("fact_ids"))
+            and bool(supported_chat.get("evidence_ids")),
+            "unsupported_premise_refused": bool(unsupported_chat.get("refused")),
+            "contradicted_premise_refused": bool(contradicted_chat.get("refused")),
+            "subject_isolation_refused": bool(isolation_chat.get("refused")),
+        }
+        steps.append(
+            _step(
+                name="api_queries",
+                ok=all(checks.values()),
+                checks=checks,
+                alice_answer=supported_chat.get("answer"),
+                alice_fact_ids=supported_chat.get("fact_ids", []),
+                alice_evidence_ids=supported_chat.get("evidence_ids", []),
+            )
+        )
+
+        for step in steps:
+            if not step["ok"]:
+                failures.append(step["name"])
+
+        artifact = {
+            "artifact_type": "live_operator_smoke",
+            "ok": not failures,
+            "provider": provider,
+            "model": model,
+            "base_url": base_url,
+            "storage_engine": "postgres",
+            "storage_role": "primary",
+            "database_url": run_db_url,
+            "maintenance_database_url": maintenance_database_url,
+            "root": str(root),
+            "port": selected_port,
+            "steps": steps,
+            "failures": failures,
+        }
+        if output_path is not None:
+            artifact["artifact_path"] = str(output_path)
+            _write_json(output_path, artifact)
+        return artifact
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+            process.kill()
+        drop_postgres_database(
+            maintenance_database_url=maintenance_database_url,
+            db_name=db_name,
+        )

--- a/src/memco/llm.py
+++ b/src/memco/llm.py
@@ -31,6 +31,9 @@ class LLMTextResponse:
     model: str
 
 
+OPENAI_COMPATIBLE_PROVIDER_NAMES = {"openai", "openai-compatible", "openai_compatible"}
+
+
 class LLMProvider(Protocol):
     name: str
     model: str
@@ -228,23 +231,54 @@ class OpenAICompatibleLLMProvider:
         )
 
 
+def _normalize_provider_name(provider: str) -> str:
+    normalized = provider.strip().lower()
+    if normalized in OPENAI_COMPATIBLE_PROVIDER_NAMES:
+        return "openai-compatible"
+    return normalized
+
+
+def _nonempty_setting(value: str | None) -> bool:
+    return bool(value and value.strip())
+
+
 def llm_runtime_policy(settings) -> dict[str, Any]:
-    provider = settings.llm.provider.strip().lower()
+    provider = _normalize_provider_name(settings.llm.provider)
     runtime_profile = getattr(settings, "runtime_profile", "repo-local")
     provider_is_mock = provider == "mock"
-    fixture_only = provider_is_mock
-    release_eligible = runtime_profile == "repo-local" and not fixture_only
-    if provider_is_mock and runtime_profile == "fixture":
-        reason = "mock provider enabled for explicit fixture/test runtime"
+    base_url_present = False
+    credentials_present = False
+    provider_configured = False
+    fixture_only = provider_is_mock or runtime_profile == "fixture"
+
+    if provider == "openai-compatible":
+        base_url_present = _nonempty_setting(getattr(settings.llm, "base_url", ""))
+        credentials_present = _nonempty_setting(getattr(settings.llm, "api_key", ""))
+        provider_configured = base_url_present and credentials_present
+
+    release_eligible = runtime_profile == "repo-local" and not provider_is_mock and provider_configured
+    if runtime_profile == "fixture":
+        reason = "fixture runtime is not release-eligible"
     elif provider_is_mock:
         reason = "mock provider is fixture-only and does not satisfy the live runtime contract"
+    elif provider != "openai-compatible":
+        reason = f"unsupported provider '{provider}'"
+    elif not base_url_present and not credentials_present:
+        reason = "openai-compatible provider is missing base_url and api_key"
+    elif not base_url_present:
+        reason = "openai-compatible provider is missing base_url"
+    elif not credentials_present:
+        reason = "openai-compatible provider is missing api_key"
     else:
-        reason = "provider is eligible for live runtime extraction"
+        reason = "provider is configured for live runtime extraction"
     return {
         "provider": provider,
         "model": settings.llm.model,
         "runtime_profile": runtime_profile,
         "allow_mock_provider": bool(getattr(settings.llm, "allow_mock_provider", False)),
+        "credentials_present": credentials_present,
+        "base_url_present": base_url_present,
+        "provider_configured": provider_configured,
         "fixture_only": fixture_only,
         "release_eligible": release_eligible,
         "reason": reason,
@@ -257,7 +291,7 @@ def build_llm_provider(
     json_handler: Callable[..., Any] | None = None,
     text_handler: Callable[..., str] | None = None,
 ) -> LLMProvider:
-    provider = settings.llm.provider.strip().lower()
+    provider = _normalize_provider_name(settings.llm.provider)
     if provider == "mock":
         if not getattr(settings.llm, "allow_mock_provider", False):
             raise ValueError("Mock LLM provider is fixture/test-only. Set llm.allow_mock_provider=true to opt in.")
@@ -266,7 +300,7 @@ def build_llm_provider(
             json_handler=json_handler,
             text_handler=text_handler,
         )
-    if provider in {"openai", "openai-compatible", "openai_compatible"}:
+    if provider == "openai-compatible":
         return OpenAICompatibleLLMProvider(
             model=settings.llm.model,
             base_url=settings.llm.base_url,

--- a/src/memco/llm_usage.py
+++ b/src/memco/llm_usage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,16 @@ class LLMUsageEvent:
     created_at: str = field(default_factory=isoformat_z)
 
 
+def estimate_token_count(*texts: str) -> int:
+    total = 0
+    for text in texts:
+        cleaned = (text or "").strip()
+        if not cleaned:
+            continue
+        total += max(1, math.ceil(len(cleaned) / 4))
+    return total
+
+
 class LLMUsageTracker:
     def __init__(self) -> None:
         self._events: list[LLMUsageEvent] = []
@@ -35,13 +46,14 @@ class LLMUsageTracker:
     def record(self, event: LLMUsageEvent) -> None:
         self._events.append(event)
 
-    def summary(self) -> dict:
-        deterministic = [event for event in self._events if event.deterministic]
-        llm = [event for event in self._events if not event.deterministic]
+    def summary(self, *, start_index: int = 0) -> dict:
+        events = self._events[start_index:]
+        deterministic = [event for event in events if event.deterministic]
+        llm = [event for event in events if not event.deterministic]
         return {
             "implemented": True,
             "status": "tracked",
-            "events_logged": len(self._events),
+            "events_logged": len(events),
             "llm_usage": self._aggregate(llm),
             "deterministic_usage": self._aggregate(deterministic),
         }

--- a/src/memco/local_artifacts.py
+++ b/src/memco/local_artifacts.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 from memco.release_check import run_release_check, run_strict_release_check
@@ -54,6 +56,16 @@ def _step_by_name(artifact: dict, name: str) -> dict:
         if step.get("name") == name:
             return step
     raise KeyError(f"release artifact is missing required step: {name}")
+
+
+@contextmanager
+def _without_live_smoke_env():
+    previous = os.environ.pop("MEMCO_RUN_LIVE_SMOKE", None)
+    try:
+        yield
+    finally:
+        if previous is not None:
+            os.environ["MEMCO_RUN_LIVE_SMOKE"] = previous
 
 
 def build_change_group_snapshot(*, project_root: Path) -> dict:
@@ -119,6 +131,7 @@ def build_repo_local_status_snapshot(
     release_postgres_artifact: dict | None,
     strict_release_artifact: dict | None,
     benchmark_artifact: dict | None,
+    live_operator_smoke_artifact: dict | None,
     contract_stack_summary: str,
     full_suite_summary: str,
     change_groups_path: Path,
@@ -187,6 +200,19 @@ def build_repo_local_status_snapshot(
             "adversarial_robustness": benchmark_artifact["benchmark_metrics"]["adversarial_robustness"],
             "person_isolation": benchmark_artifact["benchmark_metrics"]["person_isolation"],
         }
+    if live_operator_smoke_artifact is not None:
+        payload["validation"]["live_operator_smoke"] = {
+            "artifact_path": live_operator_smoke_artifact["artifact_path"],
+            "ok": live_operator_smoke_artifact["ok"],
+            "published_total": next(
+                (step.get("published_total") for step in live_operator_smoke_artifact.get("steps", []) if step.get("name") == "ingest_pipeline"),
+                None,
+            ),
+            "api_queries_ok": next(
+                (step.get("ok") for step in live_operator_smoke_artifact.get("steps", []) if step.get("name") == "api_queries"),
+                None,
+            ),
+        }
     return payload
 
 
@@ -194,7 +220,8 @@ def refresh_local_artifacts(*, project_root: Path, postgres_database_url: str | 
     reports_dir = project_root / "var" / "reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
 
-    release_artifact = run_release_check(project_root=project_root, include_eval=True)
+    with _without_live_smoke_env():
+        release_artifact = run_release_check(project_root=project_root, include_eval=True)
     release_path = reports_dir / "release-check-current.json"
     release_artifact["artifact_path"] = str(release_path)
     release_path.write_text(json.dumps(release_artifact, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -202,22 +229,25 @@ def refresh_local_artifacts(*, project_root: Path, postgres_database_url: str | 
     release_postgres_artifact = None
     strict_release_artifact = None
     benchmark_artifact = None
+    live_operator_smoke_artifact = None
     if postgres_database_url:
-        release_postgres_artifact = run_release_check(
-            project_root=project_root,
-            include_eval=True,
-            postgres_database_url=postgres_database_url,
-        )
+        with _without_live_smoke_env():
+            release_postgres_artifact = run_release_check(
+                project_root=project_root,
+                include_eval=True,
+                postgres_database_url=postgres_database_url,
+            )
         release_pg_path = reports_dir / "release-check-postgres-current.json"
         release_postgres_artifact["artifact_path"] = str(release_pg_path)
         release_pg_path.write_text(
             json.dumps(release_postgres_artifact, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
-        strict_release_artifact = run_strict_release_check(
-            project_root=project_root,
-            postgres_database_url=postgres_database_url,
-        )
+        with _without_live_smoke_env():
+            strict_release_artifact = run_strict_release_check(
+                project_root=project_root,
+                postgres_database_url=postgres_database_url,
+            )
         strict_release_path = reports_dir / "strict-release-check-current.json"
         strict_release_artifact["artifact_path"] = str(strict_release_path)
         strict_release_path.write_text(
@@ -232,6 +262,9 @@ def refresh_local_artifacts(*, project_root: Path, postgres_database_url: str | 
             json.dumps(benchmark_artifact, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        live_smoke_path = reports_dir / "live-operator-smoke-current.json"
+        if live_smoke_path.exists():
+            live_operator_smoke_artifact = json.loads(live_smoke_path.read_text(encoding="utf-8"))
 
     change_groups = build_change_group_snapshot(project_root=project_root)
     change_groups_path = reports_dir / "change-groups-current.json"
@@ -248,6 +281,7 @@ def refresh_local_artifacts(*, project_root: Path, postgres_database_url: str | 
         release_postgres_artifact=release_postgres_artifact,
         strict_release_artifact=strict_release_artifact,
         benchmark_artifact=benchmark_artifact,
+        live_operator_smoke_artifact=live_operator_smoke_artifact,
         contract_stack_summary=contract_stack_summary,
         full_suite_summary=full_suite_summary,
         change_groups_path=change_groups_path,
@@ -263,6 +297,7 @@ def refresh_local_artifacts(*, project_root: Path, postgres_database_url: str | 
             "release_check_postgres": str(reports_dir / "release-check-postgres-current.json") if postgres_database_url else None,
             "strict_release_check": str(reports_dir / "strict-release-check-current.json") if postgres_database_url else None,
             "benchmark": str(reports_dir / "benchmark-current.json") if postgres_database_url else None,
+            "live_operator_smoke": str(reports_dir / "live-operator-smoke-current.json") if live_operator_smoke_artifact is not None else None,
             "repo_local_status": str(status_path),
             "change_groups": str(change_groups_path),
         },
@@ -286,6 +321,9 @@ def refresh_local_artifacts(*, project_root: Path, postgres_database_url: str | 
             ),
             "benchmark_core_memory_accuracy": (
                 benchmark_artifact["benchmark_metrics"]["core_memory_accuracy"] if benchmark_artifact is not None else None
+            ),
+            "live_operator_smoke_ok": (
+                live_operator_smoke_artifact["ok"] if live_operator_smoke_artifact is not None else None
             ),
         },
     }

--- a/src/memco/release_check.py
+++ b/src/memco/release_check.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from memco.config import load_settings, write_settings
+from memco.live_smoke import run_live_operator_smoke
 from memco.llm import llm_runtime_policy
 from memco.postgres_smoke import run_postgres_smoke
 from memco.runtime import ensure_runtime
@@ -26,6 +28,8 @@ BENCHMARK_THRESHOLDS = {
     "unsupported_premise_supported_count": 0,
     "positive_answers_missing_evidence_ids": 0,
 }
+
+OPERATOR_READINESS_MIN_PASS_RATE = 1.0
 
 
 def resolve_repo_project_root(start: Path) -> Path:
@@ -76,6 +80,67 @@ def _run_runtime_policy_gate(*, project_root: Path) -> dict:
         "root": str(project_root),
         "config_path": str(settings.config_path),
         **policy,
+    }
+
+
+def _run_storage_contract_gate(*, project_root: Path) -> dict:
+    settings = load_settings(project_root)
+    runtime_profile = settings.runtime_profile
+    storage_role = settings.storage_role
+    storage_engine = settings.storage.engine
+    expected_engine = settings.storage.contract_engine
+    operator_profile = runtime_profile == "repo-local"
+    ok = not operator_profile or storage_role == "primary"
+    if ok and operator_profile:
+        reason = "repo-local runtime is using the primary storage contract"
+    elif ok:
+        reason = "fixture runtime may use fallback storage"
+    else:
+        reason = (
+            "repo-local runtime is using fallback storage; "
+            f"expected primary {expected_engine}, got {storage_engine}"
+        )
+    return {
+        "name": "storage_contract",
+        "ok": ok,
+        "root": str(project_root),
+        "config_path": str(settings.config_path),
+        "runtime_profile": runtime_profile,
+        "storage_engine": storage_engine,
+        "storage_contract_engine": expected_engine,
+        "storage_role": storage_role,
+        "reason": reason,
+    }
+
+
+def _run_operator_safety_gate(*, project_root: Path) -> dict:
+    settings = load_settings(project_root)
+    api_token_configured = bool((settings.api.auth_token or "").strip())
+    backup_path = settings.backup_path
+    backup_path_exists = backup_path.exists()
+    runtime_profile = settings.runtime_profile
+    operator_profile = runtime_profile == "repo-local"
+    ok = (not operator_profile) or (api_token_configured and backup_path_exists)
+    if ok and operator_profile:
+        reason = "repo-local runtime has API token configured and backup path present"
+    elif ok:
+        reason = "fixture runtime skips operator-safety enforcement"
+    elif not api_token_configured and not backup_path_exists:
+        reason = "repo-local runtime is missing API token and backup path"
+    elif not api_token_configured:
+        reason = "repo-local runtime is missing API token"
+    else:
+        reason = "repo-local runtime is missing backup path"
+    return {
+        "name": "operator_safety",
+        "ok": ok,
+        "root": str(project_root),
+        "config_path": str(settings.config_path),
+        "runtime_profile": runtime_profile,
+        "api_token_configured": api_token_configured,
+        "backup_path": str(backup_path),
+        "backup_path_exists": backup_path_exists,
+        "reason": reason,
     }
 
 
@@ -149,8 +214,43 @@ def _run_postgres_gate(
     }
 
 
+def _live_smoke_requested() -> bool:
+    return os.environ.get("MEMCO_RUN_LIVE_SMOKE", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _run_live_smoke_gate(
+    *,
+    project_root: Path,
+    database_url: str,
+    live_smoke_root: Path,
+    output_path: Path | None = None,
+) -> dict:
+    result = run_live_operator_smoke(
+        maintenance_database_url=database_url,
+        root=live_smoke_root,
+        project_root=project_root,
+        output_path=output_path,
+    )
+    return {
+        "name": "live_operator_smoke",
+        "ok": result["ok"],
+        "root": result["root"],
+        "storage_engine": result["storage_engine"],
+        "storage_role": result["storage_role"],
+        "provider": result["provider"],
+        "model": result["model"],
+        "artifact_path": result.get("artifact_path"),
+        "artifact_summary": {
+            "artifact_type": result["artifact_type"],
+            "failures": result["failures"],
+            "steps": result["steps"],
+        },
+    }
+
+
 def _benchmark_policy(artifact: dict) -> dict:
     metrics = artifact["benchmark_metrics"]
+    operator_metrics = artifact.get("operator_readiness_metrics") or {}
     checks = {
         "core_memory_accuracy": {
             "value": float(metrics["core_memory_accuracy"]),
@@ -177,11 +277,19 @@ def _benchmark_policy(artifact: dict) -> dict:
             "threshold": BENCHMARK_THRESHOLDS["positive_answers_missing_evidence_ids"],
             "ok": int(metrics["positive_answers_missing_evidence_ids"]) <= BENCHMARK_THRESHOLDS["positive_answers_missing_evidence_ids"],
         },
+        "operator_readiness_pass_rate": {
+            "value": float(operator_metrics.get("pass_rate", 0.0)),
+            "threshold": OPERATOR_READINESS_MIN_PASS_RATE,
+            "ok": float(operator_metrics.get("pass_rate", 0.0)) >= OPERATOR_READINESS_MIN_PASS_RATE,
+        },
     }
     return {
         "ok": all(item["ok"] for item in checks.values()),
         "checks": checks,
-        "thresholds": dict(BENCHMARK_THRESHOLDS),
+        "thresholds": {
+            **dict(BENCHMARK_THRESHOLDS),
+            "operator_readiness_pass_rate_min": OPERATOR_READINESS_MIN_PASS_RATE,
+        },
     }
 
 
@@ -238,6 +346,12 @@ def run_release_check(
     runtime_step = _run_runtime_policy_gate(project_root=project_root)
     steps.append(runtime_step)
     ok = runtime_step["ok"]
+    storage_step = _run_storage_contract_gate(project_root=project_root)
+    steps.append(storage_step)
+    ok = ok and storage_step["ok"]
+    safety_step = _run_operator_safety_gate(project_root=project_root)
+    steps.append(safety_step)
+    ok = ok and safety_step["ok"]
     pytest_step: dict | None = None
 
     if include_pytest:
@@ -298,6 +412,26 @@ def run_release_check(
             }
         steps.append(postgres_step)
         ok = ok and postgres_step["ok"]
+
+        if _live_smoke_requested():
+            output_path = project_root / "var" / "reports" / "live-operator-smoke-current.json"
+            if ok:
+                with TemporaryDirectory(prefix="memco-live-operator-smoke-") as tmpdir:
+                    live_smoke_step = _run_live_smoke_gate(
+                        project_root=project_root,
+                        database_url=postgres_database_url,
+                        live_smoke_root=Path(tmpdir),
+                        output_path=output_path,
+                    )
+            else:
+                live_smoke_step = {
+                    "name": "live_operator_smoke",
+                    "ok": False,
+                    "skipped": True,
+                    "reason": "prior_gate_failed",
+                }
+            steps.append(live_smoke_step)
+            ok = ok and live_smoke_step["ok"]
 
     return {
         "artifact_type": "canonical_postgres_release_check" if postgres_database_url else "repo_local_release_check",

--- a/src/memco/services/answer_service.py
+++ b/src/memco/services/answer_service.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from memco.llm_usage import LLMUsageEvent, LLMUsageTracker, estimate_token_count
 from memco.models.retrieval import DetailPolicy
 
 
 class AnswerService:
     NON_FACTUAL_DOMAINS = {"style", "psychometrics"}
+
+    def __init__(self, usage_tracker: LLMUsageTracker | None = None) -> None:
+        self.usage_tracker = usage_tracker
 
     def _temporal_value(self, hit) -> tuple[str, str]:
         event_at = str(getattr(hit, "event_at", "") or "").strip()
@@ -51,6 +55,31 @@ class AnswerService:
             "evidence_ids": evidence_ids,
         }
 
+    def _record_usage(self, *, query: str, retrieval_result, answer_payload: dict) -> None:
+        if self.usage_tracker is None:
+            return
+        factual_hits = self._factual_hits(retrieval_result)
+        input_text = " ".join(
+            [
+                query,
+                " ".join(hit.summary for hit in factual_hits),
+                " ".join(retrieval_result.unsupported_claims),
+            ]
+        )
+        output_text = answer_payload["answer"]
+        self.usage_tracker.record(
+            LLMUsageEvent(
+                provider="deterministic",
+                model="rule-based-answer",
+                operation="answer",
+                input_tokens=estimate_token_count(input_text),
+                output_tokens=estimate_token_count(output_text),
+                estimated_cost_usd=0.0,
+                deterministic=True,
+                metadata={"stage": "answer"},
+            )
+        )
+
     def _factual_hits(self, retrieval_result):
         return [hit for hit in retrieval_result.hits if getattr(hit, "domain", "") not in self.NON_FACTUAL_DOMAINS]
 
@@ -86,34 +115,42 @@ class AnswerService:
         is_when_query = query.strip().lower().startswith("when") or query.strip().lower().startswith("когда")
         if retrieval_result.hits and not factual_hits:
             sanitized = retrieval_result.model_copy(update={"hits": []})
-            return self._payload(
+            payload = self._payload(
                 answer="I don't have confirmed memory evidence for that.",
                 refused=True,
                 retrieval_result=sanitized,
                 detail_policy=policy,
             )
+            self._record_usage(query=query, retrieval_result=sanitized, answer_payload=payload)
+            return payload
         if is_when_query and factual_hits:
             conflict_answer = self._temporal_conflict_answer(factual_hits)
             if conflict_answer:
-                return self._payload(
+                payload = self._payload(
                     answer=conflict_answer,
                     refused=True,
                     retrieval_result=retrieval_result,
                     detail_policy=policy,
                 )
+                self._record_usage(query=query, retrieval_result=retrieval_result, answer_payload=payload)
+                return payload
         if retrieval_result.support_level in {"unsupported", "ambiguous"}:
-            return self._payload(
+            payload = self._payload(
                 answer="I don't have confirmed memory evidence for that.",
                 refused=True,
                 retrieval_result=retrieval_result,
                 detail_policy=policy,
             )
+            self._record_usage(query=query, retrieval_result=retrieval_result, answer_payload=payload)
+            return payload
         if retrieval_result.support_level == "contradicted":
             supported = " ".join(hit.summary for hit in factual_hits).strip()
             answer = "Confirmed memory conflicts with that claim."
             if supported:
                 answer = f"{answer} {supported}".strip()
-            return self._payload(answer=answer, refused=True, retrieval_result=retrieval_result, detail_policy=policy)
+            payload = self._payload(answer=answer, refused=True, retrieval_result=retrieval_result, detail_policy=policy)
+            self._record_usage(query=query, retrieval_result=retrieval_result, answer_payload=payload)
+            return payload
         if retrieval_result.support_level == "partial":
             supported = " ".join(hit.summary for hit in factual_hits).strip()
             unsupported = " ".join(retrieval_result.unsupported_claims).strip()
@@ -121,19 +158,25 @@ class AnswerService:
                 answer = f"{supported} However, {unsupported}"
             else:
                 answer = supported or unsupported or "I only have partial memory evidence for that."
-            return self._payload(answer=answer, refused=False, retrieval_result=retrieval_result, detail_policy=policy)
+            payload = self._payload(answer=answer, refused=False, retrieval_result=retrieval_result, detail_policy=policy)
+            self._record_usage(query=query, retrieval_result=retrieval_result, answer_payload=payload)
+            return payload
         if is_when_query and factual_hits:
             first_hit = self._select_temporal_hit(factual_hits)
             if first_hit is not None:
-                return self._payload(
+                payload = self._payload(
                     answer=self._format_when_answer(first_hit),
                     refused=False,
                     retrieval_result=retrieval_result,
                     detail_policy=policy,
                 )
-        return self._payload(
+                self._record_usage(query=query, retrieval_result=retrieval_result, answer_payload=payload)
+                return payload
+        payload = self._payload(
             answer=" ".join(hit.summary for hit in factual_hits),
             refused=False,
             retrieval_result=retrieval_result,
             detail_policy=policy,
         )
+        self._record_usage(query=query, retrieval_result=retrieval_result, answer_payload=payload)
+        return payload

--- a/src/memco/services/eval_service.py
+++ b/src/memco/services/eval_service.py
@@ -422,11 +422,19 @@ class EvalService:
         "temporal_update",
         "duplicate_merge",
     }
+    OPERATOR_READINESS_CASE_GROUPS = {
+        "supported_fact",
+        "temporal_update",
+        "cross_person_contamination",
+        "unsupported_premise",
+        "review_queue_behavior",
+    }
     BENCHMARK_SETS = {
         "internal_golden_set": {"supported_fact", "duplicate_merge"},
         "adversarial_false_premise_set": {"unsupported_premise", "partial_support"},
         "temporal_set": {"temporal_update"},
         "cross_person_contamination_set": {"cross_person_contamination"},
+        "operator_readiness_set": OPERATOR_READINESS_CASE_GROUPS,
     }
 
     BEHAVIOR_CHECKS = (
@@ -457,9 +465,9 @@ class EvalService:
         retrieval_service: RetrievalService | None = None,
         refusal_service: RefusalService | None = None,
     ) -> None:
-        self.retrieval_service = retrieval_service or RetrievalService()
-        self.refusal_service = refusal_service or RefusalService()
         self.llm_usage_tracker = LLMUsageTracker()
+        self.retrieval_service = retrieval_service or RetrievalService(usage_tracker=self.llm_usage_tracker)
+        self.refusal_service = refusal_service or RefusalService(usage_tracker=self.llm_usage_tracker)
 
     def _person(self, conn, *, fact_repo: FactRepository, slug: str, display_name: str) -> dict:
         return fact_repo.upsert_person(
@@ -1251,7 +1259,7 @@ class EvalService:
             behavior_checks = self._behavior_checks(conn)
         return results, behavior_checks
 
-    def _build_common_metrics(self, *, results: list[dict]) -> dict:
+    def _build_common_metrics(self, *, results: list[dict], start_event_index: int = 0) -> dict:
         total = len(results)
         passed = sum(1 for item in results if item["passed"])
         latencies = [int(item["latency_ms"]) for item in results]
@@ -1290,7 +1298,7 @@ class EvalService:
                 "missing_evidence_cases": [item["name"] for item in hit_cases if item["evidence_count"] == 0],
             },
             "retrieval_latency_ms": self._latency_summary(latencies),
-            "token_accounting": self.llm_usage_tracker.summary(),
+            "token_accounting": self.llm_usage_tracker.summary(start_index=start_event_index),
             "groups": groups,
         }
 
@@ -1316,18 +1324,32 @@ class EvalService:
             "providers": sorted(set(before.get("providers", [])) | set(after.get("providers", []))),
         }
 
-    def _token_accounting_by_stage(self, *, before: dict, after: dict) -> dict[str, dict]:
-        llm_usage = self._usage_delta(before["llm_usage"], after["llm_usage"])
-        deterministic_usage = self._usage_delta(before["deterministic_usage"], after["deterministic_usage"])
+    def _token_accounting_by_stage(self, *, start_event_index: int) -> dict[str, dict]:
+        stage_events = self.llm_usage_tracker.events[start_event_index:]
+
+        def aggregate(stage: str) -> dict[str, object]:
+            selected = [event for event in stage_events if event.metadata.get("stage") == stage]
+            deterministic = [event for event in selected if event.deterministic]
+            llm = [event for event in selected if not event.deterministic]
+            if llm:
+                status = "measured_llm"
+            elif deterministic:
+                status = "deterministic"
+            else:
+                status = "not_applicable"
+            return {
+                "status": status,
+                "operation_count": len(selected),
+                "input_tokens": sum(event.input_tokens for event in selected),
+                "output_tokens": sum(event.output_tokens for event in selected),
+                "providers": sorted({event.provider for event in selected}),
+            }
+
         return {
-            "extraction": {
-                "status": "measured_delta",
-                "input_tokens": deterministic_usage["input_tokens"] + llm_usage["input_tokens"],
-                "output_tokens": deterministic_usage["output_tokens"] + llm_usage["output_tokens"],
-            },
-            "planner": {"status": "not_instrumented", "input_tokens": 0, "output_tokens": 0},
-            "retrieval": {"status": "not_instrumented", "input_tokens": 0, "output_tokens": 0},
-            "answer": {"status": "not_instrumented", "input_tokens": 0, "output_tokens": 0},
+            "extraction": aggregate("extraction"),
+            "planner": aggregate("planner"),
+            "retrieval": aggregate("retrieval"),
+            "answer": aggregate("answer"),
         }
 
     def _benchmark_domain_reports(self, *, results: list[dict]) -> dict[str, dict]:
@@ -1355,8 +1377,9 @@ class EvalService:
         return reports
 
     def _run_acceptance_cases(self, project_root: Path) -> dict:
+        start_event_index = len(self.llm_usage_tracker.events)
         results, behavior_checks = self._execute_cases(project_root, cases=self.CASES, route_name="eval")
-        metrics = self._build_common_metrics(results=results)
+        metrics = self._build_common_metrics(results=results, start_event_index=start_event_index)
         return {
             "artifact_type": "eval_acceptance_artifact",
             "release_scope": "private-single-user",
@@ -1372,12 +1395,18 @@ class EvalService:
 
     def run_benchmark(self, project_root: Path) -> dict:
         benchmark_cases = tuple(case for case in self.CASES if case.group in self.BENCHMARK_CASE_GROUPS)
-        before = self.llm_usage_tracker.summary()
+        operator_readiness_cases = tuple(case for case in self.CASES if case.group in self.OPERATOR_READINESS_CASE_GROUPS)
+        start_event_index = len(self.llm_usage_tracker.events)
         results, _behavior_checks = self._execute_cases(project_root, cases=benchmark_cases, route_name="benchmark")
-        metrics = self._build_common_metrics(results=results)
+        operator_results, _operator_behavior_checks = self._execute_cases(
+            project_root,
+            cases=operator_readiness_cases,
+            route_name="operator_readiness",
+        )
+        metrics = self._build_common_metrics(results=results, start_event_index=start_event_index)
         benchmark_sets = self._benchmark_set_reports(results=results)
-        after = self.llm_usage_tracker.summary()
-        token_accounting_by_stage = self._token_accounting_by_stage(before=before, after=after)
+        operator_readiness_passed = sum(1 for item in operator_results if item["passed"])
+        token_accounting_by_stage = self._token_accounting_by_stage(start_event_index=start_event_index)
         unsupported_premise_supported_count = sum(
             1
             for item in results
@@ -1393,6 +1422,7 @@ class EvalService:
             "release_scope": "benchmark-only",
             "benchmark_scope": "internal-approximation",
             "benchmark_disclaimer": "synthetic benchmark; not paper-equivalent",
+            "operator_readiness_scope": "hand-authored-small-set",
             "benchmark_metrics": {
                 "core_memory_accuracy": benchmark_sets["internal_golden_set"]["pass_rate"],
                 "adversarial_robustness": benchmark_sets["adversarial_false_premise_set"]["pass_rate"],
@@ -1406,6 +1436,14 @@ class EvalService:
                 "token_accounting_by_stage": token_accounting_by_stage,
                 "extra_prompt_tokens": token_accounting_by_stage["extraction"]["input_tokens"],
             },
+            "operator_readiness_metrics": {
+                "pass_rate": round(operator_readiness_passed / len(operator_results), 4)
+                if operator_results
+                else 0.0,
+                "total": len(operator_results),
+                "passed": operator_readiness_passed,
+                "groups": sorted(self.OPERATOR_READINESS_CASE_GROUPS),
+            },
             "benchmark_thresholds": {
                 "core_memory_accuracy_min": 0.9,
                 "adversarial_robustness_min": 0.95,
@@ -1415,6 +1453,7 @@ class EvalService:
             },
             "benchmark_cases": results,
             "benchmark_sets": benchmark_sets,
+            "operator_readiness_cases": operator_results,
             "domain_reports": self._benchmark_domain_reports(results=results),
         }
 

--- a/src/memco/services/extraction_service.py
+++ b/src/memco/services/extraction_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from memco.config import Settings
 from memco.extractors import ExtractionOrchestrator
@@ -130,6 +131,7 @@ class ExtractionService:
             estimated_cost_usd=usage.estimated_cost_usd,
             deterministic=self.llm_provider.name == "mock",
             metadata={
+                "stage": "extraction",
                 "schema_name": metadata.get("schema_name"),
                 "message_id": metadata.get("message_id"),
                 "workspace_id": metadata.get("workspace_id"),
@@ -141,6 +143,214 @@ class ExtractionService:
         self.usage_tracker.record(event)
         if self.usage_file_logger is not None:
             self.usage_file_logger.record(event)
+
+    def _default_evidence_item(
+        self,
+        *,
+        quote: str,
+        message_id: int | None,
+        source_segment_id: int | None,
+        session_id: int | None,
+    ) -> dict[str, Any]:
+        return {
+            "quote": quote.strip(),
+            "message_ids": [str(message_id)] if message_id is not None else [],
+            "source_segment_ids": [int(source_segment_id)] if source_segment_id is not None else [],
+            "session_ids": [int(session_id)] if session_id is not None else [],
+            "chunk_kind": "conversation",
+        }
+
+    def _normalize_provider_evidence(
+        self,
+        *,
+        evidence: Any,
+        fallback_quote: str,
+        message_id: int | None,
+        source_segment_id: int | None,
+        session_id: int | None,
+    ) -> list[dict[str, Any]]:
+        default_item = self._default_evidence_item(
+            quote=fallback_quote,
+            message_id=message_id,
+            source_segment_id=source_segment_id,
+            session_id=session_id,
+        )
+        if evidence is None:
+            return []
+        if isinstance(evidence, str) and evidence.strip():
+            return [
+                self._default_evidence_item(
+                    quote=evidence,
+                    message_id=message_id,
+                    source_segment_id=source_segment_id,
+                    session_id=session_id,
+                )
+            ]
+        if isinstance(evidence, list):
+            if not evidence:
+                return []
+            normalized: list[dict[str, Any]] = []
+            for item in evidence:
+                if isinstance(item, str) and item.strip():
+                    normalized.append(
+                        self._default_evidence_item(
+                            quote=item,
+                            message_id=message_id,
+                            source_segment_id=source_segment_id,
+                            session_id=session_id,
+                        )
+                    )
+                    continue
+                if not isinstance(item, dict):
+                    continue
+                quote = item.get("quote")
+                if not isinstance(quote, str) or not quote.strip():
+                    quote = fallback_quote
+                normalized.append(
+                    {
+                        "quote": quote.strip(),
+                        "message_ids": item.get("message_ids")
+                        if isinstance(item.get("message_ids"), list)
+                        else list(default_item["message_ids"]),
+                        "source_segment_ids": item.get("source_segment_ids")
+                        if isinstance(item.get("source_segment_ids"), list)
+                        else list(default_item["source_segment_ids"]),
+                        "session_ids": item.get("session_ids")
+                        if isinstance(item.get("session_ids"), list)
+                        else list(default_item["session_ids"]),
+                        "chunk_kind": item.get("chunk_kind")
+                        if isinstance(item.get("chunk_kind"), str) and item.get("chunk_kind", "").strip()
+                        else default_item["chunk_kind"],
+                    }
+                )
+            if normalized:
+                return normalized
+        return []
+
+    def _normalize_provider_candidate(
+        self,
+        *,
+        candidate: dict[str, Any],
+        text: str,
+        subject_display: str,
+        person_id: int | None,
+        message_id: int | None,
+        source_segment_id: int | None,
+        session_id: int | None,
+    ) -> dict[str, Any]:
+        normalized = dict(candidate)
+        domain = str(normalized.get("domain") or "")
+        payload = normalized.get("payload")
+        if not isinstance(payload, dict):
+            payload = {}
+            normalized["payload"] = payload
+        category = str(normalized.get("category") or "")
+        optional_blank_string_fields = {
+            ("preferences", "preference"): {"strength", "reason"},
+            ("social_circle", "relationship_event"): {"context"},
+            ("work", "employment"): set(),
+            ("work", "role"): set(),
+            ("work", "org"): set(),
+            ("work", "project"): set(),
+            ("work", "skill"): set(),
+            ("work", "tool"): set(),
+            ("experiences", "event"): {"summary", "temporal_anchor", "outcome", "valence"},
+        }
+        removable_fields = optional_blank_string_fields.get((domain, category), set())
+        for key in list(payload.keys()):
+            value = payload.get(key)
+            if key in removable_fields and (not isinstance(value, str) or not value.strip()):
+                payload.pop(key, None)
+        lowered_text = text.lower()
+        residence_markers = (" live in ", " moved to ", " based in ", " is my base")
+        residence_value = None
+        for key in ("city", "place", "value"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                residence_value = value.strip()
+                break
+        if domain == "biography" and residence_value and any(marker in f" {lowered_text} " for marker in residence_markers):
+            normalized["category"] = "residence"
+            normalized["subcategory"] = "city"
+            normalized["payload"] = {"city": residence_value}
+            payload = normalized["payload"]
+        if domain == "biography" and category == "city" and isinstance(payload.get("city"), str):
+            normalized["category"] = "residence"
+            normalized["subcategory"] = "city"
+        if domain == "social_circle" and category == "relationship" and isinstance(payload.get("relation"), str):
+            normalized["category"] = str(payload["relation"]).strip().lower()
+        normalized["summary"] = self._normalize_provider_summary(
+            subject_display=subject_display,
+            domain=domain,
+            category=str(normalized.get("category") or ""),
+            payload=payload,
+            summary=str(normalized.get("summary") or ""),
+        )
+        normalized["evidence"] = self._normalize_provider_evidence(
+            evidence=candidate.get("evidence"),
+            fallback_quote=text,
+            message_id=message_id,
+            source_segment_id=source_segment_id,
+            session_id=session_id,
+        )
+        review_reason_codes = {"speaker_unresolved", "relation_target_unresolved"}
+        review_reasons: list[str] = []
+        existing_reason = normalized.get("reason")
+        if isinstance(existing_reason, str):
+            review_reasons.extend(
+                part.strip()
+                for part in existing_reason.split(",")
+                if part.strip() in review_reason_codes
+            )
+        if person_id is None and "speaker_unresolved" not in review_reasons:
+            review_reasons.append("speaker_unresolved")
+        if (
+            domain == "social_circle"
+            and isinstance(payload.get("target_label"), str)
+            and payload.get("target_label", "").strip()
+            and payload.get("target_person_id") is None
+            and "relation_target_unresolved" not in review_reasons
+        ):
+            review_reasons.append("relation_target_unresolved")
+        normalized["needs_review"] = bool(review_reasons)
+        if review_reasons:
+            normalized["reason"] = ",".join(review_reasons)
+        return normalized
+
+    def _normalize_provider_summary(
+        self,
+        *,
+        subject_display: str,
+        domain: str,
+        category: str,
+        payload: dict[str, Any],
+        summary: str,
+    ) -> str:
+        if domain == "biography" and category == "residence" and isinstance(payload.get("city"), str):
+            return f"{subject_display} lives in {payload['city'].strip()}."
+        if domain == "biography" and category == "origin" and isinstance(payload.get("place"), str):
+            return f"{subject_display} is from {payload['place'].strip()}."
+        if domain == "preferences" and category == "preference" and isinstance(payload.get("value"), str):
+            value = payload["value"].strip()
+            polarity = str(payload.get("polarity") or "").strip().lower()
+            if polarity == "dislike":
+                return f"{subject_display} dislikes {value}."
+            return f"{subject_display} likes {value}."
+        if domain == "social_circle" and isinstance(payload.get("target_label"), str):
+            target = payload["target_label"].strip()
+            relation = str(payload.get("relation") or category).strip()
+            if category == "relationship_event" and isinstance(payload.get("event"), str):
+                return f"{subject_display} {payload['event'].strip()} {target}."
+            return f"{subject_display} says {target} is their {relation}."
+        if domain == "work" and category == "employment" and isinstance(payload.get("title"), str):
+            return f"{subject_display} works as {payload['title'].strip()}."
+        if domain == "work" and category == "role" and isinstance(payload.get("role"), str):
+            return f"{subject_display} works as {payload['role'].strip()}."
+        if domain == "work" and category == "org" and isinstance(payload.get("org"), str):
+            return f"{subject_display} works at {payload['org'].strip()}."
+        if domain == "experiences" and category == "event" and isinstance(payload.get("event"), str):
+            return f"{subject_display} experienced {payload['event'].strip()}."
+        return summary
 
     def _extract_candidates_via_provider(
         self,
@@ -205,7 +415,20 @@ class ExtractionService:
             content = content["items"]
         if not isinstance(content, list):
             raise ValueError("LLM provider returned non-list candidate payload")
-        return [validate_candidate(candidate) for candidate in content]
+        return [
+            validate_candidate(
+                self._normalize_provider_candidate(
+                    candidate=candidate,
+                    text=text,
+                    subject_display=subject_display,
+                    person_id=person_id,
+                    message_id=message_id,
+                    source_segment_id=source_segment_id,
+                    session_id=session_id,
+                )
+            )
+            for candidate in content
+        ]
 
     def extract_candidates(self, *, source_text: str, person_hint: str | None = None) -> list[dict]:
         text = source_text.strip()

--- a/src/memco/services/planner_service.py
+++ b/src/memco/services/planner_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import re
 
+from memco.llm_usage import LLMUsageEvent, LLMUsageTracker, estimate_token_count
 from memco.models.retrieval import RetrievalClaimCheck, RetrievalDomainPlan, RetrievalPlan, RetrievalRequest
 
 
@@ -83,10 +85,30 @@ BEFORE_TARGET_RE = re.compile(r"\bbefore\s+([A-Z][A-Za-z0-9&.\-]+)\b", re.IGNORE
 
 
 class PlannerService:
+    def __init__(self, usage_tracker: LLMUsageTracker | None = None) -> None:
+        self.usage_tracker = usage_tracker
+
+    def _record_usage(self, *, query: str, plan: RetrievalPlan) -> None:
+        if self.usage_tracker is None:
+            return
+        payload = json.dumps(plan.model_dump(mode="json"), ensure_ascii=False, sort_keys=True)
+        self.usage_tracker.record(
+            LLMUsageEvent(
+                provider="deterministic",
+                model="rule-based-planner",
+                operation="plan",
+                input_tokens=estimate_token_count(query),
+                output_tokens=estimate_token_count(payload),
+                estimated_cost_usd=0.0,
+                deterministic=True,
+                metadata={"stage": "planner"},
+            )
+        )
+
     def plan(self, payload: RetrievalRequest) -> RetrievalPlan:
         temporal_mode = self._resolve_temporal_mode(payload.query, payload.temporal_mode)
         if payload.domain or payload.category:
-            return RetrievalPlan(
+            plan = RetrievalPlan(
                 plan_version="v2",
                 question_type=self._question_type(payload.query, temporal_mode=temporal_mode),
                 domain_queries=[
@@ -104,6 +126,8 @@ class PlannerService:
                 claim_checks=self._claim_checks(payload.query, person_slug=payload.person_slug),
                 support_expectation=self._support_expectation(payload.query, 1),
             )
+            self._record_usage(query=payload.query, plan=plan)
+            return plan
 
         domain_queries: list[RetrievalDomainPlan] = []
         seen: set[tuple[str, str | None]] = set()
@@ -133,7 +157,7 @@ class PlannerService:
                 )
             )
 
-        return RetrievalPlan(
+        plan = RetrievalPlan(
             plan_version="v2",
             question_type=self._question_type(payload.query, temporal_mode=temporal_mode),
             domain_queries=domain_queries,
@@ -145,6 +169,8 @@ class PlannerService:
             claim_checks=self._claim_checks(payload.query, person_slug=payload.person_slug),
             support_expectation=self._support_expectation(payload.query, len({item.domain for item in domain_queries})),
         )
+        self._record_usage(query=payload.query, plan=plan)
+        return plan
 
     def _resolve_temporal_mode(self, query: str, requested_mode: str) -> str:
         temporal_mode = requested_mode

--- a/src/memco/services/retrieval_service.py
+++ b/src/memco/services/retrieval_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import time
 
+from memco.llm_usage import LLMUsageEvent, LLMUsageTracker, estimate_token_count
 from memco.repositories.retrieval_log_repository import RetrievalLogRepository
 from memco.models.retrieval import DetailPolicy, RetrievalHit, RetrievalPlan, RetrievalRequest, RetrievalResult
 from memco.repositories.fact_repository import FactRepository
@@ -36,11 +38,39 @@ class RetrievalService:
         fact_repository: FactRepository | None = None,
         retrieval_log_repository: RetrievalLogRepository | None = None,
         planner_service: PlannerService | None = None,
+        usage_tracker: LLMUsageTracker | None = None,
     ) -> None:
         self.retrieval_repository = retrieval_repository or RetrievalRepository()
         self.fact_repository = fact_repository or FactRepository()
         self.retrieval_log_repository = retrieval_log_repository or RetrievalLogRepository()
-        self.planner_service = planner_service or PlannerService()
+        self.usage_tracker = usage_tracker
+        self.planner_service = planner_service or PlannerService(usage_tracker=usage_tracker)
+
+    def _record_usage(self, *, query: str, result: RetrievalResult) -> None:
+        if self.usage_tracker is None:
+            return
+        output = json.dumps(
+            {
+                "support_level": result.support_level,
+                "hit_count": len(result.hits),
+                "fallback_hit_count": len(result.fallback_hits),
+                "unsupported_claims": result.unsupported_claims,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        self.usage_tracker.record(
+            LLMUsageEvent(
+                provider="deterministic",
+                model="rule-based-retrieval",
+                operation="retrieve",
+                input_tokens=estimate_token_count(query),
+                output_tokens=estimate_token_count(output),
+                estimated_cost_usd=0.0,
+                deterministic=True,
+                metadata={"stage": "retrieval"},
+            )
+        )
 
     def _hash_query(self, *, query: str, salt: str) -> str:
         return hashlib.sha256(f"{salt}:{query}".encode("utf-8")).hexdigest()
@@ -191,6 +221,7 @@ class RetrievalService:
                 latency_ms=max(0, int((time.perf_counter() - started) * 1000)),
                 settings=settings,
             )
+            self._record_usage(query=payload.query, result=result)
             return result
         if person_id is None:
             try:
@@ -218,6 +249,7 @@ class RetrievalService:
                     latency_ms=max(0, int((time.perf_counter() - started) * 1000)),
                     settings=settings,
                 )
+                self._record_usage(query=payload.query, result=result)
                 return result
         person = self.fact_repository.get_person(
             conn,
@@ -241,6 +273,7 @@ class RetrievalService:
                 latency_ms=max(0, int((time.perf_counter() - started) * 1000)),
                 settings=settings,
             )
+            self._record_usage(query=payload.query, result=result)
             return result
         if actor is not None and actor.allowed_person_ids and person_id not in actor.allowed_person_ids:
             result = self._empty_result(
@@ -258,6 +291,7 @@ class RetrievalService:
                 latency_ms=max(0, int((time.perf_counter() - started) * 1000)),
                 settings=settings,
             )
+            self._record_usage(query=payload.query, result=result)
             return result
         domain_queries = planner.domain_queries
         if actor is not None and actor.allowed_domains:
@@ -288,6 +322,7 @@ class RetrievalService:
                     latency_ms=max(0, int((time.perf_counter() - started) * 1000)),
                     settings=settings,
                 )
+                self._record_usage(query=payload.query, result=result)
                 return result
         raw_hits: list[dict] = []
         for domain_query in domain_queries:
@@ -368,6 +403,7 @@ class RetrievalService:
             latency_ms=max(0, int((time.perf_counter() - started) * 1000)),
             settings=settings,
         )
+        self._record_usage(query=payload.query, result=result)
         return result
 
     def _hit_haystacks(self, *, hits: list[dict]) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,33 @@ from memco.config import Settings
 from memco.runtime import ensure_runtime
 
 
+@pytest.fixture(autouse=True)
+def isolate_memco_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "MEMCO_ROOT",
+        "MEMCO_API_HOST",
+        "MEMCO_API_PORT",
+        "MEMCO_API_TOKEN",
+        "MEMCO_REQUIRE_ACTOR_SCOPE",
+        "MEMCO_LLM_PROVIDER",
+        "MEMCO_LLM_MODEL",
+        "MEMCO_LLM_BASE_URL",
+        "MEMCO_LLM_API_KEY",
+        "MEMCO_LLM_ALLOW_MOCK_PROVIDER",
+        "MEMCO_STORAGE_ENGINE",
+        "MEMCO_DATABASE_URL",
+        "MEMCO_BACKUP_PATH",
+        "MEMCO_ENABLE_RETRIEVAL_LOGS",
+        "MEMCO_QUERY_HASH_SALT",
+        "MEMCO_RUNTIME_PROFILE",
+        "MEMCO_RUN_LIVE_SMOKE",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
 @pytest.fixture()
 def project_root(tmp_path: Path) -> Path:
     return tmp_path / "memco-project"

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -23,7 +23,13 @@ def test_health_returns_runtime_snapshot(monkeypatch, settings):
     assert payload["storage_contract"] == "postgres-primary"
     assert payload["storage_role"] == "fallback"
     assert Path(payload["database_target"]) == settings.db_path
+    assert payload["api_token_configured"] is False
+    assert payload["backup_path"].endswith("var/backups/memco-postgres.dump")
+    assert payload["backup_path_exists"] is False
     assert payload["llm_runtime"]["provider"] == "mock"
     assert payload["llm_runtime"]["runtime_profile"] == "fixture"
+    assert payload["llm_runtime"]["credentials_present"] is False
+    assert payload["llm_runtime"]["base_url_present"] is False
+    assert payload["llm_runtime"]["provider_configured"] is False
     assert payload["llm_runtime"]["fixture_only"] is True
     assert payload["llm_runtime"]["release_eligible"] is False

--- a/tests/test_cli_release_check.py
+++ b/tests/test_cli_release_check.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from click.testing import CliRunner
 from typer.main import get_command
 
 from memco.cli.main import app
+
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _plain(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
 
 
 def _seed_repo_root(path: Path) -> Path:
@@ -254,4 +262,6 @@ def test_cli_strict_release_check_requires_postgres_url(tmp_path):
     )
 
     assert result.exit_code != 0
-    assert "--postgres-database-url is required" in result.output
+    plain = _plain(result.output)
+    assert "--postgres-database-url" in plain
+    assert "required for strict-release-check" in plain

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -866,15 +866,17 @@ def test_cli_flow_commands_advertise_next_steps(settings):
 
     result = runner.invoke(command, ["eval-run", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "release-check" in result.output
+    eval_help = _plain(result.output)
+    assert "release-check" in eval_help
 
     result = runner.invoke(command, ["review-resolve", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "--latest-review" in result.output
-    assert "Resolved person slug" in result.output
-    assert "Resolved target" in result.output
-    assert "--publish" in result.output
-    assert "--person-slug" in result.output
+    review_resolve_help = _plain(result.output)
+    assert "--latest-review" in review_resolve_help
+    assert "Resolved person slug" in review_resolve_help
+    assert "Resolved target" in review_resolve_help
+    assert "--publish" in review_resolve_help
+    assert "--person-slug" in review_resolve_help
 
 
 def test_cli_operator_flow_supports_latest_shortcuts(settings, tmp_path):

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -818,44 +818,51 @@ def test_cli_flow_commands_advertise_next_steps(settings):
 
     result = runner.invoke(command, ["fact-delete", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "fact-restore" in result.output
-    assert "retrieve" in result.output
-    assert "--latest-fact" in result.output
-    assert "--person-slug" in result.output
+    fact_delete_help = _plain(result.output)
+    assert "fact-restore" in fact_delete_help
+    assert "retrieve" in fact_delete_help
+    assert "--latest-fact" in fact_delete_help
+    assert "--person-slug" in fact_delete_help
 
     result = runner.invoke(command, ["fact-restore", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "fact-list" in result.output
-    assert "retrieve" in result.output
-    assert "--latest-fact" in result.output
-    assert "--person-slug" in result.output
+    fact_restore_help = _plain(result.output)
+    assert "fact-list" in fact_restore_help
+    assert "retrieve" in fact_restore_help
+    assert "--latest-fact" in fact_restore_help
+    assert "--person-slug" in fact_restore_help
 
     result = runner.invoke(command, ["person-list", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "person-alias-upsert" in result.output
-    assert "person-merge" in result.output
+    person_list_help = _plain(result.output)
+    assert "person-alias-upsert" in person_list_help
+    assert "person-merge" in person_list_help
 
     result = runner.invoke(command, ["person-alias-upsert", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "conversation-speaker-resolve" in result.output
-    assert "candidate-extract" in result.output
+    alias_help = _plain(result.output)
+    assert "conversation-speaker-resolve" in alias_help
+    assert "candidate-extract" in alias_help
 
     result = runner.invoke(command, ["person-merge", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "person-list" in result.output
-    assert "retrieve" in result.output
+    merge_help = _plain(result.output)
+    assert "person-list" in merge_help
+    assert "retrieve" in merge_help
 
     result = runner.invoke(command, ["fact-add", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "retrieve" in result.output
-    assert "fact-operations" in result.output
-    assert "--latest-source" in result.output
+    fact_add_help = _plain(result.output)
+    assert "retrieve" in fact_add_help
+    assert "fact-operations" in fact_add_help
+    assert "--latest-source" in fact_add_help
 
     result = runner.invoke(command, ["retrieval-log-list", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "retrieve" in result.output
-    assert "chat" in result.output
-    assert "--person-slug" in result.output
+    retrieval_log_help = _plain(result.output)
+    assert "retrieve" in retrieval_log_help
+    assert "chat" in retrieval_log_help
+    assert "--person-slug" in retrieval_log_help
 
     result = runner.invoke(command, ["eval-run", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 from click.testing import CliRunner
 from typer.main import get_command
@@ -13,6 +14,13 @@ from memco.repositories.review_repository import ReviewRepository
 from memco.repositories.source_repository import SourceRepository
 from memco.services.conversation_ingest_service import ConversationIngestService
 from memco.services.ingest_service import IngestService
+
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _plain(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
 
 
 def test_cli_init_and_person_upsert(settings):
@@ -726,23 +734,27 @@ def test_cli_flow_commands_advertise_next_steps(settings):
 
     result = runner.invoke(command, ["import", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "conversation-import SOURCE_ID" in result.output
+    import_help = _plain(result.output)
+    assert "conversation-import SOURCE_ID" in import_help
 
     result = runner.invoke(command, ["conversation-import", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "candidate-extract" in result.output
-    assert "CONVERSATION_ID" in result.output
-    assert "--latest-source" in result.output
+    conversation_help = _plain(result.output)
+    assert "candidate-extract" in conversation_help
+    assert "CONVERSATION_ID" in conversation_help
+    assert "--latest-source" in conversation_help
 
     result = runner.invoke(command, ["candidate-extract", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "candidate-publish" in result.output
-    assert "review-list" in result.output
-    assert "--latest-conversation" in result.output
+    extract_help = _plain(result.output)
+    assert "candidate-publish" in extract_help
+    assert "review-list" in extract_help
+    assert "--latest-conversation" in extract_help
 
     result = runner.invoke(command, ["candidate-publish", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "retrieve" in result.output
+    publish_help = _plain(result.output)
+    assert "retrieve" in publish_help
     assert "fact-operations" in result.output
     assert "--latest-candidate" in result.output
     assert "--person-slug" in result.output

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -757,56 +757,64 @@ def test_cli_flow_commands_advertise_next_steps(settings):
     assert "retrieve" in publish_help
     assert "fact-operations" in publish_help
     assert "--latest-candidate" in publish_help
-    assert "--person-slug" in result.output
-    assert "--domain" in result.output
+    assert "--person-slug" in publish_help
+    assert "--domain" in publish_help
 
     result = runner.invoke(command, ["candidate-reject", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "--latest-candidate" in result.output
-    assert "--person-slug" in result.output
-    assert "--domain" in result.output
+    reject_help = _plain(result.output)
+    assert "--latest-candidate" in reject_help
+    assert "--person-slug" in reject_help
+    assert "--domain" in reject_help
 
     result = runner.invoke(command, ["fact-rollback", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "fact-list" in result.output
-    assert "retrieve" in result.output
-    assert "--latest-operation" in result.output
+    rollback_help = _plain(result.output)
+    assert "fact-list" in rollback_help
+    assert "retrieve" in rollback_help
+    assert "--latest-operation" in rollback_help
 
     result = runner.invoke(command, ["conversation-speakers", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "conversation-speaker-resolve" in result.output
-    assert "candidate-extract" in result.output
-    assert "--latest-conversation" in result.output
+    speakers_help = _plain(result.output)
+    assert "conversation-speaker-resolve" in speakers_help
+    assert "candidate-extract" in speakers_help
+    assert "--latest-conversation" in speakers_help
 
     result = runner.invoke(command, ["conversation-speaker-resolve", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "candidate-extract" in result.output
-    assert "CONVERSATION_ID" in result.output
-    assert "--latest-conversation" in result.output
+    speaker_resolve_help = _plain(result.output)
+    assert "candidate-extract" in speaker_resolve_help
+    assert "CONVERSATION_ID" in speaker_resolve_help
+    assert "--latest-conversation" in speaker_resolve_help
 
     result = runner.invoke(command, ["candidate-list", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "candidate-publish" in result.output
-    assert "review-resolve" in result.output
-    assert "--person-slug" in result.output
+    candidate_list_help = _plain(result.output)
+    assert "candidate-publish" in candidate_list_help
+    assert "review-resolve" in candidate_list_help
+    assert "--person-slug" in candidate_list_help
 
     result = runner.invoke(command, ["review-list", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "review-resolve" in result.output
-    assert "candidate-list" in result.output
-    assert "--person-slug" in result.output
+    review_list_help = _plain(result.output)
+    assert "review-resolve" in review_list_help
+    assert "candidate-list" in review_list_help
+    assert "--person-slug" in review_list_help
 
     result = runner.invoke(command, ["fact-list", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "candidate-publish" in result.output
-    assert "fact-rollback" in result.output
-    assert "--person-slug" in result.output
+    fact_list_help = _plain(result.output)
+    assert "candidate-publish" in fact_list_help
+    assert "fact-rollback" in fact_list_help
+    assert "--person-slug" in fact_list_help
 
     result = runner.invoke(command, ["fact-operations", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output
-    assert "fact-rollback" in result.output
-    assert "--latest-target-fact" in result.output
-    assert "--person-slug" in result.output
+    fact_ops_help = _plain(result.output)
+    assert "fact-rollback" in fact_ops_help
+    assert "--latest-target-fact" in fact_ops_help
+    assert "--person-slug" in fact_ops_help
 
     result = runner.invoke(command, ["fact-delete", "--help"], prog_name="memco")
     assert result.exit_code == 0, result.output

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -755,8 +755,8 @@ def test_cli_flow_commands_advertise_next_steps(settings):
     assert result.exit_code == 0, result.output
     publish_help = _plain(result.output)
     assert "retrieve" in publish_help
-    assert "fact-operations" in result.output
-    assert "--latest-candidate" in result.output
+    assert "fact-operations" in publish_help
+    assert "--latest-candidate" in publish_help
     assert "--person-slug" in result.output
     assert "--domain" in result.output
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -27,12 +27,14 @@ def test_readme_uses_current_contract_language():
     assert "uv run memco strict-release-check" in readme
     assert "var/reports/strict-release-check-current.json" in readme
     assert "var/reports/benchmark-current.json" in readme
+    assert "var/reports/live-operator-smoke-current.json" in readme
     assert "var/reports/repo-local-status-current.json" in readme
     assert "var/reports/change-groups-current.json" in readme
     assert "var/reports/local-artifacts-refresh-current.json" in readme
     assert "var/reports/local-artifacts-refresh-postgres-current.json" in readme
     assert "uv run memco local-artifacts-refresh --project-root /Users/martin/memco" in readme
     assert "--output /absolute/path/to/local-artifacts-refresh.json" in readme
+    assert "MEMCO_RUN_LIVE_SMOKE=1" in readme
     assert "uv run memco ingest-pipeline /absolute/path/to/conversation.json" in readme
     assert "/v1/ingest/pipeline" in readme
     assert "conversation-import --latest-source" in readme
@@ -82,12 +84,14 @@ def test_release_gate_is_active_repo_local_gate_with_reference_pointer():
     assert "uv run memco strict-release-check" in gate
     assert "var/reports/strict-release-check-current.json" in gate
     assert "var/reports/benchmark-current.json" in gate
+    assert "var/reports/live-operator-smoke-current.json" in gate
     assert "Quick contract-facing regression stack:" in gate
     assert "tests/test_release_check.py" in gate
     assert "tests/test_llm_provider.py" in gate
     assert "uv run memco local-artifacts-refresh --project-root /Users/martin/memco" in gate
     assert "var/reports/local-artifacts-refresh-current.json" in gate
     assert "var/reports/local-artifacts-refresh-postgres-current.json" in gate
+    assert "MEMCO_RUN_LIVE_SMOKE=1" in gate
     assert "## Strict Original Brief Reference Track" in gate
     assert "## Strict Original Execution-Brief Readiness" not in gate
 
@@ -116,6 +120,8 @@ def test_postgres_without_docker_guide_mentions_integrated_release_check():
     assert "strict-release-check --project-root /Users/martin/memco --postgres-database-url" in guide
     assert "var/reports/strict-release-check-current.json" in guide
     assert "var/reports/benchmark-current.json" in guide
+    assert "var/reports/live-operator-smoke-current.json" in guide
+    assert "MEMCO_BACKUP_PATH" in guide
 
 
 def test_local_operator_artifacts_are_gitignored_but_tracked_status_snapshot_is_not():
@@ -184,9 +190,10 @@ def test_repo_local_status_snapshot_tracks_current_contract_split():
     assert "Active repo-local contract status: `GO`" in snapshot
     assert "strict original brief: `NO-GO`" in snapshot
     assert "Contract-facing regression stack:" in snapshot
-    assert "46 passed" in snapshot
+    assert "74 passed" in snapshot
     assert "var/reports/release-check-current.json" in snapshot
     assert "var/reports/release-check-postgres-current.json" in snapshot
+    assert "var/reports/live-operator-smoke-current.json" in snapshot
     assert "var/reports/repo-local-status-current.json" in snapshot
     assert "mirrors the current branch, remote, contract split, and latest validation counts" in snapshot
     assert "var/reports/change-groups-current.json" in snapshot
@@ -217,3 +224,4 @@ def test_repo_local_status_snapshot_captures_handoff_grade_context():
     assert "var/reports/release-check-postgres-current.json" in snapshot
     assert "fact_ids" in snapshot
     assert "evidence_ids" in snapshot
+    assert "operator safety now requires" in snapshot

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -129,13 +129,17 @@ def test_eval_harness_emits_separate_benchmark_artifact(settings):
     assert result["benchmark_scope"] == "internal-approximation"
     assert result["release_scope"] == "benchmark-only"
     assert result["benchmark_disclaimer"] == "synthetic benchmark; not paper-equivalent"
+    assert result["operator_readiness_scope"] == "hand-authored-small-set"
     assert "benchmark_metrics" in result
+    assert "operator_readiness_metrics" in result
     assert "benchmark_cases" in result
+    assert "operator_readiness_cases" in result
     assert "benchmark_sets" in result
     assert "internal_golden_set" in result["benchmark_sets"]
     assert "adversarial_false_premise_set" in result["benchmark_sets"]
     assert "temporal_set" in result["benchmark_sets"]
     assert "cross_person_contamination_set" in result["benchmark_sets"]
+    assert "operator_readiness_set" in result["benchmark_sets"]
     assert "domain_reports" in result
     assert "biography" in result["domain_reports"]
     assert "core_memory_accuracy" in result["benchmark_metrics"]
@@ -148,7 +152,18 @@ def test_eval_harness_emits_separate_benchmark_artifact(settings):
     assert "p50" in result["benchmark_metrics"]["retrieval_latency_ms"]
     assert "token_accounting_by_stage" in result["benchmark_metrics"]
     assert "extra_prompt_tokens" in result["benchmark_metrics"]
-    assert result["benchmark_metrics"]["token_accounting_by_stage"]["planner"]["status"] == "not_instrumented"
+    assert result["benchmark_metrics"]["token_accounting_by_stage"]["extraction"]["status"] == "not_applicable"
+    assert result["benchmark_metrics"]["token_accounting_by_stage"]["planner"]["status"] == "deterministic"
+    assert result["benchmark_metrics"]["token_accounting_by_stage"]["retrieval"]["status"] == "deterministic"
+    assert result["benchmark_metrics"]["token_accounting_by_stage"]["answer"]["status"] == "deterministic"
+    assert result["benchmark_metrics"]["token_accounting_by_stage"]["planner"]["input_tokens"] > 0
+    assert result["benchmark_metrics"]["token_accounting_by_stage"]["answer"]["output_tokens"] > 0
+    assert result["operator_readiness_metrics"]["pass_rate"] == 1.0
+    assert result["operator_readiness_metrics"]["passed"] == result["operator_readiness_metrics"]["total"]
+    assert "supported_fact" in result["operator_readiness_metrics"]["groups"]
+    assert "review_queue_behavior" in result["operator_readiness_metrics"]["groups"]
+    assert all(case["group"] in result["operator_readiness_metrics"]["groups"] for case in result["operator_readiness_cases"])
+    assert any(case["group"] == "review_queue_behavior" for case in result["operator_readiness_cases"])
     assert result["benchmark_thresholds"]["core_memory_accuracy_min"] == 0.9
     assert result["benchmark_thresholds"]["adversarial_robustness_min"] == 0.95
     assert result["benchmark_thresholds"]["person_isolation_min"] == 0.99

--- a/tests/test_extraction_contracts.py
+++ b/tests/test_extraction_contracts.py
@@ -65,6 +65,7 @@ def test_prompt_payload_embeds_output_contract():
 
     assert payload["contract_version"]
     assert payload["extraction_mode"] == "llm_first_structured_extraction"
+    assert payload["json_output_required"] is True
     assert payload["output_contract"]["top_level_output"]["required_keys"] == ["items"]
     domains = {item["domain"] for item in payload["output_contract"]["domains"]}
     assert {"biography", "preferences", "social_circle", "work", "experiences", "psychometrics"} <= domains

--- a/tests/test_live_smoke.py
+++ b/tests/test_live_smoke.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from memco.live_smoke import run_live_operator_smoke
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def wait(self, timeout: int | None = None) -> int:
+        return 0
+
+    def kill(self) -> None:  # pragma: no cover - defensive
+        self.killed = True
+
+
+def test_run_live_operator_smoke_emits_compact_artifact(monkeypatch, tmp_path):
+    root = tmp_path / "runtime"
+    project_root = tmp_path / "repo"
+    output_path = tmp_path / "artifacts" / "live-operator-smoke.json"
+    project_root.mkdir()
+    monkeypatch.setenv("MEMCO_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("MEMCO_LLM_MODEL", "gpt-5.4-mini")
+    monkeypatch.setenv("MEMCO_LLM_BASE_URL", "http://127.0.0.1:2455/v1")
+    monkeypatch.setenv("MEMCO_LLM_API_KEY", "secret")
+    monkeypatch.setenv("MEMCO_API_TOKEN", "smoke-token")
+    monkeypatch.setattr(
+        "memco.live_smoke.ensure_postgres_database",
+        lambda **kwargs: "postgresql://martin@127.0.0.1:5432/memco_live_smoke_12345",
+    )
+    monkeypatch.setattr("memco.live_smoke.drop_postgres_database", lambda **kwargs: None)
+    monkeypatch.setattr("memco.live_smoke.ensure_runtime", lambda settings: settings)
+    monkeypatch.setattr("memco.live_smoke.subprocess.Popen", lambda *args, **kwargs: _FakeProcess())
+
+    def fake_wait_http(url: str, *, timeout_seconds: int = 30):
+        assert url.endswith("/health")
+        return {
+            "storage_engine": "postgres",
+            "storage_role": "primary",
+            "llm_runtime": {"release_eligible": True},
+        }
+
+    def fake_request_json(*, url: str, method: str = "GET", payload=None, headers=None, timeout: int = 60, retries: int = 0):
+        if url.endswith("/v1/ingest/pipeline") and payload["person_slug"] == "alice":
+            return {
+                "published": [
+                    {"fact": {"domain": "biography", "category": "residence"}},
+                    {"fact": {"domain": "preferences", "category": "preference"}},
+                    {"fact": {"domain": "work", "category": "org"}},
+                    {"fact": {"domain": "work", "category": "role"}},
+                    {"fact": {"domain": "work", "category": "tool"}},
+                    {"fact": {"domain": "experiences", "category": "event"}},
+                ],
+                "pending_review_items": [],
+            }
+        if url.endswith("/v1/ingest/pipeline") and payload["person_slug"] == "bob":
+            return {
+                "published": [
+                    {"fact": {"domain": "biography", "category": "residence"}},
+                    {"fact": {"domain": "preferences", "category": "preference"}},
+                    {"fact": {"domain": "work", "category": "org"}},
+                    {"fact": {"domain": "work", "category": "role"}},
+                ],
+                "pending_review_items": [],
+            }
+        if url.endswith("/v1/retrieve") and payload["person_slug"] == "alice":
+            return {
+                "hits": [
+                    {
+                        "fact_id": 1,
+                        "domain": "biography",
+                        "category": "residence",
+                        "summary": "Alice lives in Lisbon.",
+                        "evidence": [{"evidence_id": 10}],
+                    }
+                ]
+            }
+        if url.endswith("/v1/retrieve") and payload["person_slug"] == "bob":
+            return {
+                "hits": [
+                    {
+                        "fact_id": 2,
+                        "domain": "biography",
+                        "category": "residence",
+                        "summary": "Bob lives in Porto.",
+                        "evidence": [{"evidence_id": 20}],
+                    }
+                ]
+            }
+        if url.endswith("/v1/chat") and payload["query"] == "Where does Alice live?":
+            return {
+                "refused": False,
+                "answer": "Alice lives in Lisbon.",
+                "fact_ids": [1],
+                "evidence_ids": [10],
+            }
+        if url.endswith("/v1/chat") and payload["query"] in {
+            "Is Bob Alice's brother?",
+            "Does Alice live in Berlin?",
+            "Where does Bob live?",
+        }:
+            return {
+                "refused": True,
+                "answer": "I don't have confirmed memory evidence for that.",
+                "fact_ids": [],
+                "evidence_ids": [],
+            }
+        raise AssertionError(f"Unexpected request: {method} {url} {payload}")
+
+    monkeypatch.setattr("memco.live_smoke._wait_http", fake_wait_http)
+    monkeypatch.setattr("memco.live_smoke._request_json", fake_request_json)
+
+    result = run_live_operator_smoke(
+        maintenance_database_url="postgresql://martin@127.0.0.1:5432/postgres",
+        root=root,
+        project_root=project_root,
+        output_path=output_path,
+    )
+
+    assert result["artifact_type"] == "live_operator_smoke"
+    assert result["ok"] is True
+    assert result["provider"] == "openai-compatible"
+    assert result["storage_engine"] == "postgres"
+    assert result["storage_role"] == "primary"
+    assert result["failures"] == []
+    assert output_path.exists()
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written["ok"] is True
+    assert any(step["name"] == "ingest_pipeline" for step in written["steps"])
+    assert any(step["name"] == "api_queries" for step in written["steps"])

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -10,7 +10,7 @@ import pytest
 from memco.config import Settings
 from memco.config import load_settings
 from memco.db import get_connection
-from memco.llm import MockLLMProvider, OpenAICompatibleLLMProvider, build_llm_provider
+from memco.llm import MockLLMProvider, OpenAICompatibleLLMProvider, build_llm_provider, llm_runtime_policy
 from memco.repositories.fact_repository import FactRepository
 from memco.services.conversation_ingest_service import ConversationIngestService
 from memco.services.extraction_service import ExtractionService
@@ -327,6 +327,36 @@ def test_extraction_service_from_settings_defaults_to_openai_compatible_runtime(
     assert service.llm_provider.name == "openai-compatible"
 
 
+def test_llm_runtime_policy_requires_credentials_for_openai_compatible_provider():
+    settings = Settings(root=Path("/tmp/memco-test-runtime-policy-missing-key"))
+
+    policy = llm_runtime_policy(settings)
+
+    assert policy["provider"] == "openai-compatible"
+    assert policy["runtime_profile"] == "repo-local"
+    assert policy["base_url_present"] is True
+    assert policy["credentials_present"] is False
+    assert policy["provider_configured"] is False
+    assert policy["fixture_only"] is False
+    assert policy["release_eligible"] is False
+    assert "api_key" in policy["reason"]
+
+
+def test_llm_runtime_policy_marks_callable_openai_compatible_runtime_release_eligible():
+    settings = Settings(root=Path("/tmp/memco-test-runtime-policy-live"))
+    settings.llm.base_url = "https://router.example/v1"
+    settings.llm.api_key = "secret"
+
+    policy = llm_runtime_policy(settings)
+
+    assert policy["provider"] == "openai-compatible"
+    assert policy["base_url_present"] is True
+    assert policy["credentials_present"] is True
+    assert policy["provider_configured"] is True
+    assert policy["fixture_only"] is False
+    assert policy["release_eligible"] is True
+
+
 def test_extraction_service_rejects_mock_config_without_explicit_opt_in(tmp_path):
     root = tmp_path / "project"
     (root / "var" / "config").mkdir(parents=True, exist_ok=True)
@@ -453,6 +483,35 @@ def test_extraction_service_rejects_malformed_provider_candidates():
         assert "candidate is missing required keys" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected malformed provider candidate to be rejected")
+
+
+def test_extraction_service_normalizes_string_evidence_from_provider():
+    provider = MockLLMProvider(
+        model="fixture-x",
+        json_handler=lambda **kwargs: {
+            "items": [
+                {
+                    "domain": "biography",
+                    "category": "residence",
+                    "subcategory": "",
+                    "canonical_key": "alice:biography:residence:lisbon",
+                    "payload": {"city": "Lisbon"},
+                    "summary": "Alice lives in Lisbon.",
+                    "confidence": 0.9,
+                    "reason": "",
+                    "needs_review": False,
+                    "evidence": "I moved to Lisbon.",
+                }
+            ]
+        },
+    )
+
+    service = ExtractionService(llm_provider=provider)
+    candidates = service.extract_candidates(source_text="I moved to Lisbon.", person_hint="Alice")
+
+    assert candidates[0]["payload"]["city"] == "Lisbon"
+    assert candidates[0]["evidence"][0]["quote"] == "I moved to Lisbon."
+    assert candidates[0]["evidence"][0]["chunk_kind"] == "conversation"
 
 
 def test_extraction_service_openai_compatible_live_http_path():

--- a/tests/test_local_artifacts.py
+++ b/tests/test_local_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -11,6 +12,22 @@ def test_refresh_local_artifacts_writes_expected_reports(monkeypatch, tmp_path):
     project_root = tmp_path / "memco"
     reports_dir = project_root / "var" / "reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
+    (reports_dir / "live-operator-smoke-current.json").write_text(
+        json.dumps(
+            {
+                "artifact_type": "live_operator_smoke",
+                "ok": True,
+                "steps": [
+                    {"name": "ingest_pipeline", "published_total": 10},
+                    {"name": "api_queries", "ok": True},
+                ],
+                "artifact_path": str(reports_dir / "live-operator-smoke-current.json"),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
 
     def fake_run_release_check(*, project_root, include_eval, postgres_database_url=None):
         artifact = {
@@ -109,6 +126,7 @@ def test_refresh_local_artifacts_writes_expected_reports(monkeypatch, tmp_path):
     assert result["summaries"]["release_check_postgres_pytest_gate"] == "41 passed in 1.00s"
     assert result["summaries"]["strict_release_check_gate_type"] == "strict-quality"
     assert result["summaries"]["benchmark_core_memory_accuracy"] == 1.0
+    assert result["summaries"]["live_operator_smoke_ok"] is True
     assert release["artifact_path"].endswith("release-check-current.json")
     assert release_pg["artifact_path"].endswith("release-check-postgres-current.json")
     assert strict_release["artifact_path"].endswith("strict-release-check-current.json")
@@ -119,7 +137,93 @@ def test_refresh_local_artifacts_writes_expected_reports(monkeypatch, tmp_path):
     assert status["validation"]["release_check_postgres"]["gate_type"] == "canonical-postgres"
     assert status["validation"]["strict_release_check"]["gate_type"] == "strict-quality"
     assert status["validation"]["benchmark"]["core_memory_accuracy"] == 1.0
+    assert status["validation"]["live_operator_smoke"]["ok"] is True
+    assert status["validation"]["live_operator_smoke"]["published_total"] == 10
     assert status["change_groups_artifact"].endswith("change-groups-current.json")
     grouped_paths = {path for items in groups["groups"].values() for path in items}
     assert "README.md" in grouped_paths
     assert "src/memco/api/routes/export.py" in grouped_paths
+
+
+def test_refresh_local_artifacts_clears_live_smoke_env(monkeypatch, tmp_path):
+    project_root = tmp_path / "memco"
+    reports_dir = project_root / "var" / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("MEMCO_RUN_LIVE_SMOKE", "1")
+
+    def fake_run_release_check(*, project_root, include_eval, postgres_database_url=None):
+        assert os.environ.get("MEMCO_RUN_LIVE_SMOKE") is None
+        artifact = {
+            "artifact_type": "canonical_postgres_release_check" if postgres_database_url else "repo_local_release_check",
+            "ok": True,
+            "gate_type": "canonical-postgres" if postgres_database_url else "quick-repo-local",
+            "steps": [
+                {"name": "runtime_policy", "ok": True, "provider": "openai-compatible", "runtime_profile": "repo-local"},
+                {"name": "storage_contract", "ok": True, "storage_role": "primary"},
+                {"name": "operator_safety", "ok": True},
+                {"name": "pytest_gate", "stdout": "...\n41 passed in 1.00s\n"},
+                {"name": "acceptance_artifact", "artifact_summary": {"passed": 24, "total": 24}},
+            ],
+        }
+        if postgres_database_url:
+            artifact["steps"].append({"name": "postgres_smoke", "ok": True})
+        return artifact
+
+    def fake_run_strict_release_check(*, project_root, postgres_database_url):
+        assert os.environ.get("MEMCO_RUN_LIVE_SMOKE") is None
+        return {
+            "artifact_type": "strict_quality_release_check",
+            "ok": True,
+            "gate_type": "strict-quality",
+            "steps": [
+                {"name": "runtime_policy", "ok": True},
+                {"name": "storage_contract", "ok": True},
+                {"name": "operator_safety", "ok": True},
+                {"name": "pytest_gate", "stdout": "...\n41 passed in 1.00s\n"},
+                {"name": "acceptance_artifact", "artifact_summary": {"passed": 24, "total": 24}},
+                {"name": "postgres_smoke", "ok": True},
+                {
+                    "name": "benchmark_artifact",
+                    "ok": True,
+                    "policy_checks": {
+                        "core_memory_accuracy": {"value": 1.0},
+                        "adversarial_robustness": {"value": 1.0},
+                        "person_isolation": {"value": 1.0},
+                        "operator_readiness_pass_rate": {"value": 1.0},
+                    },
+                    "artifact_summary": {
+                        "artifact_type": "eval_benchmark_artifact",
+                        "benchmark_metrics": {
+                            "core_memory_accuracy": 1.0,
+                            "adversarial_robustness": 1.0,
+                            "person_isolation": 1.0,
+                        },
+                    },
+                },
+            ],
+        }
+
+    def fake_run(command, cwd, capture_output, text, check):
+        joined = " ".join(command)
+        if "rev-parse --abbrev-ref HEAD" in joined:
+            return subprocess.CompletedProcess(command, 0, stdout="main\n", stderr="")
+        if "remote get-url origin" in joined:
+            return subprocess.CompletedProcess(command, 0, stdout="https://example.com/repo.git\n", stderr="")
+        if "status --porcelain" in joined:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if list(command[:3]) == [str(command[0]), "-m", "pytest"]:
+            if tuple(command[4:]) == CONTRACT_STATUS_TEST_FILES:
+                return subprocess.CompletedProcess(command, 0, stdout="...\n46 passed in 0.50s\n", stderr="")
+            return subprocess.CompletedProcess(command, 0, stdout="...\n262 passed in 5.00s\n", stderr="")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr("memco.local_artifacts.run_release_check", fake_run_release_check)
+    monkeypatch.setattr("memco.local_artifacts.run_strict_release_check", fake_run_strict_release_check)
+    monkeypatch.setattr("memco.local_artifacts.subprocess.run", fake_run)
+
+    refresh_local_artifacts(
+        project_root=project_root,
+        postgres_database_url="postgresql://example/postgres",
+    )
+
+    assert os.environ.get("MEMCO_RUN_LIVE_SMOKE") == "1"

--- a/tests/test_postgres_runtime.py
+++ b/tests/test_postgres_runtime.py
@@ -80,6 +80,11 @@ def test_health_reports_postgres_target(monkeypatch, tmp_path):
     settings = Settings(root=Path(tmp_path / "project"))
     settings.storage.engine = "postgres"
     settings.storage.database_url = "postgresql://memco:memco@db:5432/memco"
+    settings.api.auth_token = "memco-token"
+    settings.backup_path.parent.mkdir(parents=True, exist_ok=True)
+    settings.backup_path.write_text("backup", encoding="utf-8")
+    settings.llm.base_url = "https://router.example/v1"
+    settings.llm.api_key = "secret"
     fake_conn = _FakePostgresConn()
 
     monkeypatch.setattr("memco.api.routes.health.get_settings", lambda: settings)
@@ -96,8 +101,13 @@ def test_health_reports_postgres_target(monkeypatch, tmp_path):
     assert payload["storage_role"] == "primary"
     assert payload["db"] == "postgresql://memco:memco@db:5432/memco"
     assert payload["database_target"] == "postgresql://memco:memco@db:5432/memco"
+    assert payload["api_token_configured"] is True
+    assert payload["backup_path_exists"] is True
     assert payload["llm_runtime"]["provider"] == "openai-compatible"
     assert payload["llm_runtime"]["runtime_profile"] == "repo-local"
+    assert payload["llm_runtime"]["credentials_present"] is True
+    assert payload["llm_runtime"]["base_url_present"] is True
+    assert payload["llm_runtime"]["provider_configured"] is True
     assert payload["llm_runtime"]["release_eligible"] is True
 
 

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -8,17 +8,31 @@ from memco.release_check import (
     ACTIVE_GATE_TEST_FILES,
     _run_benchmark_gate,
     _run_eval_gate,
+    _run_operator_safety_gate,
     _run_runtime_policy_gate,
+    _run_storage_contract_gate,
     resolve_repo_project_root,
     run_release_check,
     run_strict_release_check,
 )
 
 
+def _write_live_runtime_settings(project_root: Path) -> None:
+    settings = Settings(root=project_root)
+    settings.storage.engine = "postgres"
+    settings.llm.base_url = "https://router.example/v1"
+    settings.llm.api_key = "secret"
+    settings.api.auth_token = "memco-token"
+    settings.backup_path.parent.mkdir(parents=True, exist_ok=True)
+    settings.backup_path.write_text("backup", encoding="utf-8")
+    write_settings(settings)
+
+
 def test_run_release_check_runs_pytest_gate_and_acceptance(monkeypatch, tmp_path):
     project_root = tmp_path / "repo"
     eval_root = tmp_path / "eval-runtime"
     project_root.mkdir()
+    _write_live_runtime_settings(project_root)
     monkeypatch.setattr("memco.release_check.ensure_runtime", lambda settings: settings)
 
     monkeypatch.setattr(
@@ -64,16 +78,20 @@ def test_run_release_check_runs_pytest_gate_and_acceptance(monkeypatch, tmp_path
     assert result["ok"] is True
     assert result["gate_type"] == "quick-repo-local"
     assert result["include_pytest"] is True
-    assert [step["name"] for step in result["steps"]] == ["runtime_policy", "pytest_gate", "acceptance_artifact"]
+    assert [step["name"] for step in result["steps"]] == ["runtime_policy", "storage_contract", "operator_safety", "pytest_gate", "acceptance_artifact"]
     assert result["steps"][0]["ok"] is True
-    assert result["steps"][1]["command"][-len(ACTIVE_GATE_TEST_FILES) :] == list(ACTIVE_GATE_TEST_FILES)
-    assert result["steps"][2]["artifact_summary"]["failed"] == 0
+    assert result["steps"][1]["ok"] is True
+    assert result["steps"][1]["storage_role"] == "primary"
+    assert result["steps"][2]["ok"] is True
+    assert result["steps"][3]["command"][-len(ACTIVE_GATE_TEST_FILES) :] == list(ACTIVE_GATE_TEST_FILES)
+    assert result["steps"][4]["artifact_summary"]["failed"] == 0
     assert seen_roots == [eval_root, eval_root]
 
 
 def test_run_release_check_skips_eval_when_pytest_gate_fails(monkeypatch, tmp_path):
     project_root = tmp_path / "repo"
     project_root.mkdir()
+    _write_live_runtime_settings(project_root)
 
     monkeypatch.setattr(
         "memco.release_check.subprocess.run",
@@ -97,15 +115,16 @@ def test_run_release_check_skips_eval_when_pytest_gate_fails(monkeypatch, tmp_pa
     result = run_release_check(project_root=project_root, include_eval=True)
 
     assert result["ok"] is False
-    assert result["steps"][1]["ok"] is False
-    assert result["steps"][2]["skipped"] is True
-    assert result["steps"][2]["reason"] == "pytest_gate_failed"
+    assert result["steps"][3]["ok"] is False
+    assert result["steps"][4]["skipped"] is True
+    assert result["steps"][4]["reason"] == "pytest_gate_failed"
 
 
 def test_run_release_check_can_run_acceptance_without_pytest(monkeypatch, tmp_path):
     project_root = tmp_path / "repo"
     eval_root = tmp_path / "eval-runtime"
     project_root.mkdir()
+    _write_live_runtime_settings(project_root)
     seen_roots: list[Path] = []
     monkeypatch.setattr("memco.release_check.ensure_runtime", lambda settings: settings)
 
@@ -148,7 +167,7 @@ def test_run_release_check_can_run_acceptance_without_pytest(monkeypatch, tmp_pa
     assert result["ok"] is True
     assert result["include_pytest"] is False
     assert result["include_eval"] is True
-    assert [step["name"] for step in result["steps"]] == ["runtime_policy", "acceptance_artifact"]
+    assert [step["name"] for step in result["steps"]] == ["runtime_policy", "storage_contract", "operator_safety", "acceptance_artifact"]
     assert seen_roots == [eval_root, eval_root]
 
 
@@ -169,6 +188,7 @@ def test_run_release_check_can_run_optional_postgres_smoke(monkeypatch, tmp_path
     eval_root = tmp_path / "eval-runtime"
     postgres_root = tmp_path / "postgres-runtime"
     project_root.mkdir()
+    _write_live_runtime_settings(project_root)
     seen_roots: list[Path] = []
     monkeypatch.setattr("memco.release_check.ensure_runtime", lambda settings: settings)
 
@@ -231,12 +251,105 @@ def test_run_release_check_can_run_optional_postgres_smoke(monkeypatch, tmp_path
     assert result["artifact_type"] == "canonical_postgres_release_check"
     assert result["gate_type"] == "canonical-postgres"
     assert result["include_postgres_smoke"] is True
-    assert [step["name"] for step in result["steps"]] == ["runtime_policy", "pytest_gate", "acceptance_artifact", "postgres_smoke"]
-    assert result["steps"][2]["storage_engine"] == "postgres"
-    assert result["steps"][2]["storage_role"] == "primary"
-    assert result["steps"][3]["schema_migrations"] == 1
-    assert result["steps"][3]["health"]["storage_engine"] == "postgres"
+    assert [step["name"] for step in result["steps"]] == ["runtime_policy", "storage_contract", "operator_safety", "pytest_gate", "acceptance_artifact", "postgres_smoke"]
+    assert result["steps"][1]["storage_role"] == "primary"
+    assert result["steps"][2]["ok"] is True
+    assert result["steps"][4]["storage_engine"] == "postgres"
+    assert result["steps"][4]["storage_role"] == "primary"
+    assert result["steps"][5]["schema_migrations"] == 1
+    assert result["steps"][5]["health"]["storage_engine"] == "postgres"
     assert seen_roots == [eval_root, eval_root]
+
+
+def test_run_release_check_can_run_optional_live_smoke(monkeypatch, tmp_path):
+    project_root = tmp_path / "repo"
+    eval_root = tmp_path / "eval-runtime"
+    postgres_root = tmp_path / "postgres-runtime"
+    project_root.mkdir()
+    _write_live_runtime_settings(project_root)
+    monkeypatch.setenv("MEMCO_RUN_LIVE_SMOKE", "1")
+    monkeypatch.setattr("memco.release_check.ensure_runtime", lambda settings: settings)
+    monkeypatch.setattr(
+        "memco.release_check.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=kwargs.get("args", args[0] if args else []),
+            returncode=0,
+            stdout="5 passed\n",
+            stderr="",
+        ),
+    )
+
+    class _FakeEvalService:
+        def seed_fixture_data(self, root: Path) -> None:
+            return None
+
+        def run_acceptance(self, root: Path) -> dict:
+            return {
+                "artifact_type": "eval_acceptance_artifact",
+                "release_scope": "private-single-user",
+                "total": 20,
+                "passed": 20,
+                "failed": 0,
+                "pass_rate": 1.0,
+                "accuracy": 1.0,
+                "refusal_correctness": {"total_cases": 3, "passed_cases": 3, "rate": 1.0},
+                "evidence_coverage": {"cases_with_hits": 10, "cases_with_evidence": 10, "rate": 1.0},
+                "retrieval_latency_ms": {"min": 1, "max": 2, "avg": 1, "p95": 2},
+                "token_accounting": {"status": "tracked"},
+                "behavior_checks_total": 2,
+                "behavior_checks_passed": 2,
+                "groups": [{"name": "supported_fact", "total": 2, "passed": 2, "pass_rate": 1.0}],
+            }
+
+    monkeypatch.setattr("memco.release_check.EvalService", _FakeEvalService)
+    monkeypatch.setattr(
+        "memco.release_check.run_postgres_smoke",
+        lambda **kwargs: {
+            "health": {"ok": True, "storage_engine": "postgres", "database_target": kwargs["database_url"]},
+            "schema_migrations": 1,
+            "database_url": kwargs["database_url"],
+            "root": str(kwargs["root"]),
+            "port": kwargs["port"] or 8788,
+        },
+    )
+    monkeypatch.setattr(
+        "memco.release_check.run_live_operator_smoke",
+        lambda **kwargs: {
+            "artifact_type": "live_operator_smoke",
+            "ok": True,
+            "provider": "openai-compatible",
+            "model": "gpt-5.4-mini",
+            "storage_engine": "postgres",
+            "storage_role": "primary",
+            "root": str(kwargs["root"]),
+            "artifact_path": str(kwargs["output_path"]),
+            "failures": [],
+            "steps": [{"name": "api_queries", "ok": True}],
+        },
+    )
+
+    result = run_release_check(
+        project_root=project_root,
+        eval_root=eval_root,
+        include_pytest=True,
+        include_eval=True,
+        postgres_database_url="postgresql://example/postgres",
+        postgres_root=postgres_root,
+    )
+
+    assert result["ok"] is True
+    assert [step["name"] for step in result["steps"]] == [
+        "runtime_policy",
+        "storage_contract",
+        "operator_safety",
+        "pytest_gate",
+        "acceptance_artifact",
+        "postgres_smoke",
+        "live_operator_smoke",
+    ]
+    assert result["steps"][6]["ok"] is True
+    assert result["steps"][6]["artifact_summary"]["artifact_type"] == "live_operator_smoke"
+    assert result["steps"][6]["artifact_path"].endswith("live-operator-smoke-current.json")
 
 
 def test_run_release_check_rejects_canonical_postgres_gate_without_eval(tmp_path):
@@ -270,9 +383,122 @@ def test_run_runtime_policy_gate_rejects_live_mock_provider(tmp_path):
     assert result["ok"] is False
     assert result["provider"] == "mock"
     assert result["runtime_profile"] == "repo-local"
+    assert result["credentials_present"] is False
+    assert result["base_url_present"] is False
+    assert result["provider_configured"] is False
     assert result["fixture_only"] is True
     assert result["release_eligible"] is False
     assert "fixture-only" in result["reason"]
+
+
+def test_run_storage_contract_gate_rejects_repo_local_sqlite_fallback(tmp_path):
+    project_root = tmp_path / "repo"
+    settings = Settings(root=project_root)
+    settings.storage.engine = "sqlite"
+    write_settings(settings)
+
+    result = _run_storage_contract_gate(project_root=project_root)
+
+    assert result["name"] == "storage_contract"
+    assert result["ok"] is False
+    assert result["runtime_profile"] == "repo-local"
+    assert result["storage_engine"] == "sqlite"
+    assert result["storage_contract_engine"] == "postgres"
+    assert result["storage_role"] == "fallback"
+    assert "fallback storage" in result["reason"]
+
+
+def test_run_storage_contract_gate_accepts_fixture_sqlite_fallback(tmp_path):
+    project_root = tmp_path / "repo"
+    settings = Settings(root=project_root)
+    settings.runtime.profile = "fixture"
+    settings.storage.engine = "sqlite"
+    write_settings(settings)
+
+    result = _run_storage_contract_gate(project_root=project_root)
+
+    assert result["name"] == "storage_contract"
+    assert result["ok"] is True
+    assert result["runtime_profile"] == "fixture"
+    assert result["storage_engine"] == "sqlite"
+    assert result["storage_role"] == "fallback"
+    assert "fixture runtime" in result["reason"]
+
+
+def test_run_operator_safety_gate_rejects_repo_local_missing_token_and_backup(tmp_path):
+    project_root = tmp_path / "repo"
+    settings = Settings(root=project_root)
+    settings.storage.engine = "postgres"
+    settings.api.auth_token = ""
+    write_settings(settings)
+
+    result = _run_operator_safety_gate(project_root=project_root)
+
+    assert result["name"] == "operator_safety"
+    assert result["ok"] is False
+    assert result["runtime_profile"] == "repo-local"
+    assert result["api_token_configured"] is False
+    assert result["backup_path_exists"] is False
+
+
+def test_run_operator_safety_gate_accepts_repo_local_with_token_and_backup(tmp_path):
+    project_root = tmp_path / "repo"
+    settings = Settings(root=project_root)
+    settings.storage.engine = "postgres"
+    settings.api.auth_token = "memco-token"
+    backup_path = settings.backup_path
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    backup_path.write_text("backup", encoding="utf-8")
+    write_settings(settings)
+
+    result = _run_operator_safety_gate(project_root=project_root)
+
+    assert result["name"] == "operator_safety"
+    assert result["ok"] is True
+    assert result["api_token_configured"] is True
+    assert result["backup_path_exists"] is True
+
+
+def test_run_runtime_policy_gate_rejects_missing_openai_compatible_api_key(tmp_path):
+    project_root = tmp_path / "repo"
+    settings = Settings(root=project_root)
+    settings.llm.provider = "openai-compatible"
+    settings.llm.base_url = "https://router.example/v1"
+    settings.llm.api_key = ""
+    write_settings(settings)
+
+    result = _run_runtime_policy_gate(project_root=project_root)
+
+    assert result["name"] == "runtime_policy"
+    assert result["ok"] is False
+    assert result["provider"] == "openai-compatible"
+    assert result["runtime_profile"] == "repo-local"
+    assert result["base_url_present"] is True
+    assert result["credentials_present"] is False
+    assert result["provider_configured"] is False
+    assert result["release_eligible"] is False
+    assert "api_key" in result["reason"]
+
+
+def test_run_runtime_policy_gate_rejects_missing_openai_compatible_base_url(tmp_path):
+    project_root = tmp_path / "repo"
+    settings = Settings(root=project_root)
+    settings.llm.provider = "openai-compatible"
+    settings.llm.base_url = "   "
+    settings.llm.api_key = "secret"
+    write_settings(settings)
+
+    result = _run_runtime_policy_gate(project_root=project_root)
+
+    assert result["name"] == "runtime_policy"
+    assert result["ok"] is False
+    assert result["provider"] == "openai-compatible"
+    assert result["runtime_profile"] == "repo-local"
+    assert result["base_url_present"] is False
+    assert result["credentials_present"] is True
+    assert result["provider_configured"] is False
+    assert result["release_eligible"] is False
+    assert "base_url" in result["reason"]
 
 
 def test_run_release_check_stays_fail_closed_when_live_runtime_uses_mock(monkeypatch, tmp_path):
@@ -324,7 +550,63 @@ def test_run_release_check_stays_fail_closed_when_live_runtime_uses_mock(monkeyp
     assert result["ok"] is False
     assert result["steps"][0]["name"] == "runtime_policy"
     assert result["steps"][0]["ok"] is False
-    assert result["steps"][2]["ok"] is True
+    assert result["steps"][1]["ok"] is True
+    assert result["steps"][2]["ok"] is False
+    assert result["steps"][4]["ok"] is True
+
+
+def test_run_release_check_stays_fail_closed_when_repo_local_runtime_uses_sqlite_fallback(monkeypatch, tmp_path):
+    project_root = tmp_path / "repo"
+    eval_root = tmp_path / "eval-runtime"
+    settings = Settings(root=project_root)
+    settings.llm.base_url = "https://router.example/v1"
+    settings.llm.api_key = "secret"
+    settings.storage.engine = "sqlite"
+    write_settings(settings)
+    monkeypatch.setattr("memco.release_check.ensure_runtime", lambda settings: settings)
+
+    monkeypatch.setattr(
+        "memco.release_check.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=kwargs.get("args", args[0] if args else []),
+            returncode=0,
+            stdout="5 passed\n",
+            stderr="",
+        ),
+    )
+
+    class _FakeEvalService:
+        def seed_fixture_data(self, root: Path) -> None:
+            return None
+
+        def run_acceptance(self, root: Path) -> dict:
+            return {
+                "artifact_type": "eval_acceptance_artifact",
+                "release_scope": "private-single-user",
+                "total": 20,
+                "passed": 20,
+                "failed": 0,
+                "pass_rate": 1.0,
+                "accuracy": 1.0,
+                "refusal_correctness": {"total_cases": 3, "passed_cases": 3, "rate": 1.0},
+                "evidence_coverage": {"cases_with_hits": 10, "cases_with_evidence": 10, "rate": 1.0},
+                "retrieval_latency_ms": {"min": 1, "max": 2, "avg": 1, "p95": 2},
+                "token_accounting": {"status": "tracked"},
+                "behavior_checks_total": 2,
+                "behavior_checks_passed": 2,
+                "groups": [{"name": "supported_fact", "total": 2, "passed": 2, "pass_rate": 1.0}],
+            }
+
+    monkeypatch.setattr("memco.release_check.EvalService", _FakeEvalService)
+
+    result = run_release_check(project_root=project_root, eval_root=eval_root, include_eval=True)
+
+    assert result["ok"] is False
+    assert result["steps"][0]["ok"] is True
+    assert result["steps"][1]["name"] == "storage_contract"
+    assert result["steps"][1]["ok"] is False
+    assert result["steps"][1]["storage_role"] == "fallback"
+    assert result["steps"][4]["ok"] is True
 
 
 def test_resolve_repo_project_root_finds_parent_checkout(tmp_path):
@@ -544,8 +826,15 @@ def test_run_benchmark_gate_emits_threshold_checks(monkeypatch, tmp_path):
                     "unsupported_premise_supported_count_max": 0,
                     "positive_answers_missing_evidence_ids_max": 0,
                 },
+                "operator_readiness_metrics": {
+                    "pass_rate": 1.0,
+                    "total": 5,
+                    "passed": 5,
+                    "groups": ["supported_fact"],
+                },
                 "benchmark_sets": {},
                 "benchmark_cases": [],
+                "operator_readiness_cases": [],
                 "domain_reports": {},
             }
 
@@ -558,6 +847,8 @@ def test_run_benchmark_gate_emits_threshold_checks(monkeypatch, tmp_path):
     assert result["policy_checks"]["core_memory_accuracy"]["ok"] is True
     assert result["policy_checks"]["person_isolation"]["ok"] is True
     assert result["policy_checks"]["unsupported_premise_supported_count"]["value"] == 0
+    assert result["policy_checks"]["operator_readiness_pass_rate"]["ok"] is True
+    assert result["thresholds"]["operator_readiness_pass_rate_min"] == 1.0
 
 
 def test_run_strict_release_check_requires_benchmark_success(monkeypatch, tmp_path):
@@ -573,6 +864,8 @@ def test_run_strict_release_check_requires_benchmark_success(monkeypatch, tmp_pa
             "gate_type": "canonical-postgres",
             "steps": [
                 {"name": "runtime_policy", "ok": True},
+                {"name": "storage_contract", "ok": True, "storage_role": "primary"},
+                {"name": "operator_safety", "ok": True, "api_token_configured": True, "backup_path_exists": True},
                 {"name": "pytest_gate", "ok": True, "stdout": "5 passed\n"},
                 {"name": "acceptance_artifact", "ok": True, "artifact_summary": {"passed": 24, "total": 24}},
                 {"name": "postgres_smoke", "ok": True},
@@ -607,6 +900,8 @@ def test_run_strict_release_check_requires_benchmark_success(monkeypatch, tmp_pa
     assert result["ok"] is False
     assert [step["name"] for step in result["steps"]] == [
         "runtime_policy",
+        "storage_contract",
+        "operator_safety",
         "pytest_gate",
         "acceptance_artifact",
         "postgres_smoke",


### PR DESCRIPTION
## Summary

- harden live runtime so mock is fixture-only
- split quick, canonical Postgres, strict-quality, and live-smoke verification paths
- make extraction LLM-first and stabilize openai-compatible provider output
- add operator safety checks for API token and backup path
- separate operator-readiness from synthetic benchmark metrics
- instrument planner, retrieval, and answer token accounting by stage
- refresh local operator artifacts, docs, and handoff helpers

## Validation

- `uv run pytest -q`
- `uv run memco release-check --project-root /Users/martin/memco`
- `uv run memco strict-release-check --project-root /Users/martin/memco --postgres-database-url 'postgresql://martin@127.0.0.1:5432/postgres'`
- `MEMCO_RUN_LIVE_SMOKE=1 MEMCO_LLM_PROVIDER=openai-compatible MEMCO_LLM_MODEL=gpt-5.4-mini MEMCO_LLM_BASE_URL=http://127.0.0.1:2455/v1 MEMCO_LLM_API_KEY=... MEMCO_API_TOKEN=memco-local-operator-token uv run memco release-check --project-root /Users/martin/memco --postgres-database-url 'postgresql://martin@127.0.0.1:5432/postgres'`

## Notes

- quick acceptance gate remains available via `release-check`
- full quality claim now goes through `strict-release-check`
- live operator smoke is optional and writes `var/reports/live-operator-smoke-current.json`
- repo is still not public-safe without sanitizing absolute local paths and sibling private repo references
