### PR TITLE
Opt CI actions into Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- opt GitHub Actions workflow into Node 24 for JavaScript actions
- remove the remaining Node 20 deprecation warning from CI logs

## Validation

- `/Users/martin/memco/.venv/bin/python - <<'PY' ... yaml.safe_load(.github/workflows/ci.yml) ... PY`
- `git diff --check`

## Notes

- this is a CI-only follow-up after the merged go-live remediation PR
- no product/runtime code changed
